### PR TITLE
Feature/optimization

### DIFF
--- a/src/vml/HistoryBuffer.py
+++ b/src/vml/HistoryBuffer.py
@@ -1,6 +1,3 @@
-import copy
-
-
 class HistoryBuffer:
     def __init__(self):
         self._history = []
@@ -9,7 +6,7 @@ class HistoryBuffer:
         self._history.append({"name" : name, "data" : data, "event" : event})
 
     def getHistory(self):
-        return copy.deepcopy(self._history)
+        return self._history.copy()
 
     def clearBuffer(self):
         self._history.clear()

--- a/src/vml/VariableTracker.py
+++ b/src/vml/VariableTracker.py
@@ -8,6 +8,8 @@ except ImportError:
 LOCAL = 0
 GLOBAL = 1
 
+_ATOMIC_TYPES = (int, float, bool, str, bytes, type(None))
+
 class VariableTracker:
 
     def __init__(self, varName, domain=None, value=None, exists=False, frame=None):
@@ -24,6 +26,20 @@ class VariableTracker:
             self._isActive = True
 
     def _make_snapshot(self, value):
+        if isinstance(value, _ATOMIC_TYPES):
+            return value
+        t = type(value)
+
+        if t is list:
+            return [self._make_snapshot(v) for v in value]
+        if t is dict:
+            return {self._make_snapshot(k): self._make_snapshot(v) for k, v in value.items()}
+        if t is set:
+            return {self._make_snapshot(v) for v in value}
+        if t is frozenset:
+            return frozenset(self._make_snapshot(v) for v in value)
+        if t is tuple:
+            return tuple(self._make_snapshot(v) for v in value)
         try:
             return copy.deepcopy(value)
         except Exception:

--- a/src/vml/vml_engine.c
+++ b/src/vml/vml_engine.c
@@ -60,10 +60,48 @@ static PyObject *vml_check_variable(PyObject *self, PyObject *args)
         Py_RETURN_FALSE; 
     }
 
-    // Step4 : Checking Data in Heap
-    int diff = PyObject_RichCompareBool(reference_curr, last_val_copy, Py_NE);
+    // Step4 : Checking Data in Heap (type-specific fast-path)
+    int diff = 0;
+
+    if (PyList_Check(reference_curr)) {
+        // Fast-path : size check first
+        if (PyList_GET_SIZE(reference_curr) != PyList_GET_SIZE(last_val_copy)) {
+            Py_DECREF(reference_curr);
+            Py_RETURN_TRUE;
+        }
+        diff = PyObject_RichCompareBool(reference_curr, last_val_copy, Py_NE);
+    }
+    else if (PyDict_Check(reference_curr)) {
+        // Fast-path : size check first
+        if (PyDict_Size(reference_curr) != PyDict_Size(last_val_copy)) {
+            Py_DECREF(reference_curr);
+            Py_RETURN_TRUE;
+        }
+        diff = PyObject_RichCompareBool(reference_curr, last_val_copy, Py_NE);
+    }
+    else if (PySet_Check(reference_curr) || PyFrozenSet_Check(reference_curr)) {
+        // Fast-path : size check first
+        if (PySet_GET_SIZE(reference_curr) != PySet_GET_SIZE(last_val_copy)) {
+            Py_DECREF(reference_curr);
+            Py_RETURN_TRUE;
+        }
+        diff = PyObject_RichCompareBool(reference_curr, last_val_copy, Py_NE);
+    }
+    else if (PyTuple_Check(reference_curr)) {
+        // Fast-path : size check first (tuple containing mutable elements)
+        if (PyTuple_GET_SIZE(reference_curr) != PyTuple_GET_SIZE(last_val_copy)) {
+            Py_DECREF(reference_curr);
+            Py_RETURN_TRUE;
+        }
+        diff = PyObject_RichCompareBool(reference_curr, last_val_copy, Py_NE);
+    }
+    else {
+        // Fallback : custom class or unknown type
+        diff = PyObject_RichCompareBool(reference_curr, last_val_copy, Py_NE);
+    }
+
     Py_DECREF(reference_curr);
-    
+
     if (diff == 1) {
         Py_RETURN_TRUE;
     } else if (diff == -1) {


### PR DESCRIPTION
## Summary

Closes #5

Optimize Step 4 of `vml_check_variable` in `vml_engine.c` by introducing type-specific size fast-path before falling back to `PyObject_RichCompareBool`.

---

## Problem

In Step 4, `PyObject_RichCompareBool` was used unconditionally for all mutable types. This causes unnecessary full traversal overhead even in cases where the container size has already changed — a difference that can be detected at O(1) cost.

---

## Changes

**`vml_engine.c`**
- Replace the single `PyObject_RichCompareBool` call in Step 4 with type-specific branches
- For `list`, `dict`, `set`, `frozenset`, `tuple`: compare container size first using C-level APIs (`PyList_GET_SIZE`, `PyDict_Size`, `PySet_GET_SIZE`, `PyTuple_GET_SIZE`)
- Return `TRUE` immediately if sizes differ, skipping full traversal
- Fall back to `PyObject_RichCompareBool` if sizes are equal or type is unknown (custom class, etc.)

**`VariableTracker.py`**
- Replace `copy.deepcopy` with type-specific recursive copy in `_make_snapshot`
- Reduces snapshot creation overhead for common container types

---

## Behavior

| Case | Before | After |
|------|--------|-------|
| Container size differs | Full `RichCompareBool` traversal | Immediate `TRUE` via size check |
| Container size equal, content differs | Full `RichCompareBool` traversal | Full `RichCompareBool` traversal |
| Custom class | `RichCompareBool` | `RichCompareBool` (fallback) |

---

## Notes

- Step 1–3 are unchanged
- `tuple` is included despite being immutable at the top level, as it may contain mutable elements (e.g. `(1, [1, 2])`)
- This optimization is most effective when container size changes are the primary source of mutations