### PR TITLE
Chore/add deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,77 @@
+name: Publish vmlog to PyPI
+on:
+  release:
+    types: [published]
+
+jobs:
+  # 1. Building C Extension
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: matrix.os == 'ubuntu-latest'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build wheels via cibuildwheel
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_BUILD: "cp311-* cp312-* cp313-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+
+      - name: Upload wheels artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  # Building sdist
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: release
+      url: https://pypi.org/p/vmlog
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          merge-multiple: true
+          path: dist
+
+      - name: Check dist
+        run: pipx run twine check dist/*
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "vml"
+name = "vmlog"
 version = "1.3.1"
 authors = [{name = "sdkurjnk", email = "sdkurjnk@naver.com"}]
 license = {text = "MIT"}
@@ -14,6 +14,7 @@ keywords = ["logging", "monitoring", "c-extension"]
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Debuggers"
 ]


### PR DESCRIPTION
## 🚀 Overview
기존 프로젝트 명칭인 `vml`이 PyPI의 기존 프로젝트들과 유사도(Typosquatting 방지 규칙)가 너무 높아 등록이 반려되는 문제가 있었습니다. 

이를 해결하기 위해 프로젝트 이름을 **`vmlog`**로 변경하고, 다중 OS(Linux, Windows, macOS) 및 Python 최신 버전(3.11, 3.12, 3.13)을 지원하기 위한 **C 확장 모듈 휠 빌드 및 PyPI 자동 배포(OIDC) 워크플로우**를 전면 구축했습니다.

## 🛠️ Key Changes

### 1. 패키지 명칭 및 메타데이터 변경
- `pyproject.toml` 내 프로젝트 이름을 `vml`에서 **`vmlog`**로 수정했습니다.
- 지원 플랫폼 및 최신 파이썬 환경 명시를 위해 `classifiers`에 **Python 3.13**을 추가했습니다.

### 2. CI/CD 자동화 워크플로우 추가 (`.github/workflows/publish.yml`)
- **`cibuildwheel` 연동:** 복잡한 C 확장 모듈을 Linux, Windows, macOS 전 환경에서 `.whl` 파일로 빌드하도록 자동화했습니다. (CPython 3.11 ~ 3.13 타겟)
- **보안 강화 (OIDC):** 패키지 토큰이나 비밀번호 노출 위험이 없는 **Trusted Publisher(id-token: write)** 방식을 도입하여 `release` 환경에서 PyPI로 안전하게 자동 업로드되도록 구성했습니다.
- **검증 단계 추가:** 배포 전 `twine check`를 통해 빌드된 아티팩트의 메타데이터 결함을 사전에 검증합니다.

## 📸 Screenshots / Verification
- [ ] `pyproject.toml` 및 `.github/workflows/` 정상 반영 확인
- [ ] `twine check` 패스 확인

## 📋 Reviewer Note
- 이 PR이 메인(main) 브랜치에 머지된 후, GitHub에서 새로운 **Release를 배포(Publish)**하면 자동으로 PyPI(`https://pypi.org/p/vmlog`)에 새 버전이 릴리스됩니다.
- 배포를 실행하기 전, PyPI 웹사이트의 'Manage Providers' 메뉴에서 GitHub Repository와 `release` 환경(Environment)이 **Trusted Publisher**로 선행 등록되어 있어야 정상 작동합니다.