### PR TITLE
Feat: add LEGB scope classification (ENCLOSING / BUILTIN)

### DIFF
--- a/src/oscilo/HistoryBuffer.py
+++ b/src/oscilo/HistoryBuffer.py
@@ -4,6 +4,7 @@ class HistoryBuffer:
     _DOMAIN_LABELS = {
         0: "LOCAL",
         1: "GLOBAL",
+        2: "ENCLOSING",
     }
     _UNKNOWN_DOMAIN_LABEL = "UNKNOWN"
 

--- a/src/oscilo/ScopeResolver.py
+++ b/src/oscilo/ScopeResolver.py
@@ -1,9 +1,32 @@
+LOCAL = 0
+GLOBAL = 1
+ENCLOSING = 2
+BUILTIN = 3
+NOT_FOUND = -1
+
+
 class ScopeResolver:
     def resolve(self, frame, var_name):
-        if var_name in frame.f_locals:
-            return 0, frame.f_locals.get(var_name)
-        
+        code = frame.f_code
+
+        # Statically declared local (co_cellvars covers locals captured by inner functions).
+        if var_name in code.co_varnames or var_name in code.co_cellvars:
+            # A declared local shadows outer scopes even while unbound (deleted or
+            # not yet assigned), so report NOT_FOUND instead of falling through.
+            if var_name in frame.f_locals:
+                return LOCAL, frame.f_locals.get(var_name)
+            return NOT_FOUND, None
+
+        # Free variable captured from an enclosing function scope.
+        if var_name in code.co_freevars:
+            if var_name in frame.f_locals:
+                return ENCLOSING, frame.f_locals.get(var_name)
+            return NOT_FOUND, None
+
         if var_name in frame.f_globals:
-            return 1, frame.f_globals.get(var_name)
-        
-        return -1, None
+            return GLOBAL, frame.f_globals.get(var_name)
+
+        if var_name in frame.f_builtins:
+            return BUILTIN, frame.f_builtins.get(var_name)
+
+        return NOT_FOUND, None

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -5,7 +5,9 @@ from .VariableTracker import VariableTracker
 
 LOCAL = 0
 GLOBAL = 1
-TRACKABLE_DOMAINS = (LOCAL, GLOBAL)
+ENCLOSING = 2
+BUILTIN = 3
+TRACKABLE_DOMAINS = (LOCAL, GLOBAL, ENCLOSING)
 BUFFERED_EVENTS = ("init", "updated", "deleted")
 DELETED_EVENT = "deleted"
 
@@ -200,7 +202,7 @@ class TraceDispatcher:
         return self._trace_lines
 
     def _should_skip_tracker(self, tracker, frame):
-        if tracker.domain == LOCAL and tracker.frame is not None:
+        if tracker.domain == LOCAL or tracker.domain == ENCLOSING and tracker.frame is not None:
             return frame is not tracker.frame
 
         if tracker.domain == GLOBAL and tracker.frame is not None:

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -202,7 +202,7 @@ class TraceDispatcher:
         return self._trace_lines
 
     def _should_skip_tracker(self, tracker, frame):
-        if tracker.domain == LOCAL or tracker.domain == ENCLOSING and tracker.frame is not None:
+        if (tracker.domain == LOCAL or tracker.domain == ENCLOSING) and tracker.frame is not None:
             return frame is not tracker.frame
 
         if tracker.domain == GLOBAL and tracker.frame is not None:

--- a/src/oscilo/VariableTracker.py
+++ b/src/oscilo/VariableTracker.py
@@ -7,6 +7,8 @@ except ImportError:
 
 LOCAL = 0
 GLOBAL = 1
+ENCLOSING = 2
+BUILTIN = 3
 NOT_FOUND = -1
 
 INIT_EVENT = "init"
@@ -77,10 +79,10 @@ class VariableTracker:
         self._isActive = False
 
     def _get_current_value(self, frame, domain, varName):
-        if domain == LOCAL:
+        if domain == LOCAL or domain == ENCLOSING:
             return frame.f_locals.get(varName)
-
-        return frame.f_globals.get(varName)
+        elif domain == GLOBAL:
+            return frame.f_globals.get(varName)
 
     def _handle_missing_variable(self):
         if self._isActive:
@@ -97,7 +99,7 @@ class VariableTracker:
         if varName is None:
             varName = self.varName
 
-        if domain == NOT_FOUND:
+        if domain == NOT_FOUND or domain == BUILTIN:
             return self._handle_missing_variable()
 
         self.domain = domain

--- a/src/oscilo/oscilo_engine.c
+++ b/src/oscilo/oscilo_engine.c
@@ -2,17 +2,21 @@
 
 typedef enum {
     LOCAL = 0,
-    GLOBAL = 1
+    GLOBAL = 1,
+    ENCLOSING = 2,
+    BUILTIN = 3
 } ScopeType;
 
 static PyObject *get_scope_dict(PyObject *frame, ScopeType domain)
 {
     // Select the dictionary that should be inspected for the requested scope.
-    if (domain == LOCAL) {
+    if (domain == LOCAL || domain == ENCLOSING) {
         return PyFrame_GetLocals((PyFrameObject *)frame);
     }
-
-    return PyFrame_GetGlobals((PyFrameObject *)frame);
+    if (domain == GLOBAL) {
+        return PyFrame_GetGlobals((PyFrameObject *)frame);
+    }
+    return NULL;
 }
 
 static PyObject *get_reference_from_scope(PyObject *scope_dict, PyObject *key)

--- a/tests/test_scope_resolver_legb.py
+++ b/tests/test_scope_resolver_legb.py
@@ -1,0 +1,125 @@
+import sys
+import unittest
+
+from oscilo.ScopeResolver import ScopeResolver
+
+LOCAL = 0
+GLOBAL = 1
+ENCLOSING = 2
+BUILTIN = 3
+NOT_FOUND = -1
+
+TEST_LEGB_GLOBAL = "global-value"
+
+class TestScopeResolverLEGB(unittest.TestCase):
+    def setUp(self):
+        self.resolver = ScopeResolver()
+
+    def test_captured_local_is_classified_as_local(self):
+        captured = "cell-value"
+
+        # Referencing the variable from an inner function moves it to co_cellvars,
+        # but it must still be classified as LOCAL in the defining frame.
+        def inner():
+            return captured
+
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "captured")
+
+        self.assertEqual(domain, LOCAL)
+        self.assertEqual(value, "cell-value")
+
+    def test_free_variable_is_classified_as_enclosing(self):
+        enclosing_value = "enclosing-value"
+
+        def inner():
+            frame = sys._getframe()
+            result = self.resolver.resolve(frame, "enclosing_value")
+            # Reference the name so it stays a free variable of this code object.
+            self.assertEqual(enclosing_value, "enclosing-value")
+            return result
+
+        domain, value = inner()
+
+        self.assertEqual(domain, ENCLOSING)
+        self.assertEqual(value, "enclosing-value")
+
+    def test_module_variable_is_classified_as_global(self):
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "TEST_LEGB_GLOBAL")
+
+        self.assertEqual(domain, GLOBAL)
+        self.assertEqual(value, "global-value")
+
+    def test_builtin_name_is_classified_as_builtin(self):
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "len")
+
+        self.assertEqual(domain, BUILTIN)
+        self.assertIs(value, len)
+
+    def test_local_shadows_builtin(self):
+        len = "shadowed-builtin"
+
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "len")
+
+        self.assertEqual(domain, LOCAL)
+        self.assertEqual(value, "shadowed-builtin")
+
+    def test_enclosing_shadows_global(self):
+        TEST_LEGB_GLOBAL = "enclosing-value"
+
+        def inner():
+            frame = sys._getframe()
+            result = self.resolver.resolve(frame, "TEST_LEGB_GLOBAL")
+            self.assertEqual(TEST_LEGB_GLOBAL, "enclosing-value")
+            return result
+
+        domain, value = inner()
+
+        self.assertEqual(domain, ENCLOSING)
+        self.assertEqual(value, "enclosing-value")
+
+    def test_declared_local_shadows_global_even_while_unbound(self):
+        frame = sys._getframe()
+
+        # The assignment below makes the name a declared local for this whole
+        # function, so resolving before it binds must not fall back to the global.
+        domain, value = self.resolver.resolve(frame, "TEST_LEGB_GLOBAL")
+
+        self.assertEqual(domain, NOT_FOUND)
+        self.assertIsNone(value)
+
+        TEST_LEGB_GLOBAL = "local-value"
+        self.assertEqual(TEST_LEGB_GLOBAL, "local-value")
+
+    def test_deleted_local_is_not_found(self):
+        target = "local-value"
+        del target
+
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "target")
+
+        self.assertEqual(domain, NOT_FOUND)
+        self.assertIsNone(value)
+
+    def test_unbound_free_variable_is_not_found(self):
+        captured = "will-be-deleted"
+
+        def inner():
+            frame = sys._getframe()
+            result = self.resolver.resolve(frame, "captured")
+            # Reference the name so it stays a free variable of this code object.
+            if False:
+                captured
+            return result
+
+        del captured
+        domain, value = inner()
+
+        self.assertEqual(domain, NOT_FOUND)
+        self.assertIsNone(value)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- `ScopeResolver`를 런타임 dict 조회 순서(f_locals → f_globals)에서 **코드 객체 기반 LEGB 정적 분류**로 전환한다: `co_varnames`/`co_cellvars` → LOCAL, `co_freevars` → ENCLOSING, `f_globals` → GLOBAL, `f_builtins` → BUILTIN (설계 문서 Lib_Add-Attribute의 Method 반영)
- 선언된 지역변수가 unbound 상태(할당 전·삭제 후)일 때 외부 스코프로 fall-through하지 않고 NOT_FOUND를 반환한다 — 지역 선언이 바깥 스코프를 가리는 Python의 `UnboundLocalError` 의미론과 일치
- `TRACKABLE_DOMAINS`에 ENCLOSING이 추가되어 클로저 자유변수 추적이 가능해지고, JSONL 출력에 `"domain": "ENCLOSING"` 라벨이 기록된다

검증: 전체 테스트 45개 통과(`python tests/test.py`, C 확장 빌드 포함) + 클로저 자유변수의 init/updated 감지 및 domain 라벨 수동 확인

```json
{"name": "captured", "data": [1, 2], "event": "updated", "domain": "ENCLOSING", ...}
```

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [ ] `ScopeResolver`: LEGB 분류로 재작성, 도메인 상수(`LOCAL`/`GLOBAL`/`ENCLOSING`/`BUILTIN`/`NOT_FOUND`) 도입, 선언됐지만 unbound인 지역의 shadowing 처리
- [ ] `VariableTracker`: ENCLOSING은 `f_locals` 경유로 현재 값 조회(자유변수는 셀을 통해 f_locals에 노출됨), BUILTIN은 missing 처리로 추적 대상에서 제외
- [ ] `TraceDispatcher`: `TRACKABLE_DOMAINS`에 ENCLOSING 추가, skip 판정을 `(LOCAL or ENCLOSING) and frame` 형태로 우선순위 명시하여 확장
- [ ] `HistoryBuffer`: `_DOMAIN_LABELS`에 ENCLOSING 라벨 추가
- [ ] `oscilo_engine.c`: `ScopeType`에 ENCLOSING/BUILTIN 추가 — ENCLOSING은 `PyFrame_GetLocals` 경로 공유, 그 외 도메인은 NULL 반환으로 missing 처리
- [ ] `tests/test_scope_resolver_legb.py` 추가 (9개): 4개 도메인 분류(cellvar 포함 LOCAL / freevar ENCLOSING / GLOBAL / BUILTIN), shadowing 3종(local↔builtin, enclosing↔global, unbound 지역↔global), 삭제된 지역·unbound 자유변수의 NOT_FOUND 처리

## Issue Link
<!-- Link any related issues below. e.g., Closes #12 -->
- N/A

## Screenshots / Videos (Optional)
<!-- Attach any visual evidence, mockups, or demos if there are UI/UX changes. -->

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.