### PR TITLE
Feature/add attribute to log

### DIFF
--- a/src/oscilo/HistoryBuffer.py
+++ b/src/oscilo/HistoryBuffer.py
@@ -4,6 +4,7 @@ class HistoryBuffer:
     _DOMAIN_LABELS = {
         0: "LOCAL",
         1: "GLOBAL",
+        2: "ENCLOSING",
     }
     _UNKNOWN_DOMAIN_LABEL = "UNKNOWN"
 

--- a/src/oscilo/HistoryBuffer.py
+++ b/src/oscilo/HistoryBuffer.py
@@ -10,7 +10,7 @@ class HistoryBuffer:
     def __init__(self):
         self._history = []
 
-    def append(self, name, data, event, domain=None, line=None):
+    def append(self, name, data, event, domain=None, line=None, func=None):
         # Store a readable domain label so JSONL output is easy to inspect.
         history_entry = {
             "name": name,
@@ -18,6 +18,7 @@ class HistoryBuffer:
             "event": event,
             "domain": self._get_domain_label(domain),
             "line": line,
+            "func": func,
         }
         self._history.append(history_entry)
 

--- a/src/oscilo/HistoryBuffer.py
+++ b/src/oscilo/HistoryBuffer.py
@@ -10,7 +10,7 @@ class HistoryBuffer:
     def __init__(self):
         self._history = []
 
-    def append(self, name, data, event, domain=None, line=None, func=None):
+    def append(self, name, data, event, domain=None, line=None, func=None, call_id=None, parent_call_id=None, call_depth=None,):
         # Store a readable domain label so JSONL output is easy to inspect.
         history_entry = {
             "name": name,
@@ -19,6 +19,9 @@ class HistoryBuffer:
             "domain": self._get_domain_label(domain),
             "line": line,
             "func": func,
+            "call_id": call_id,
+            "parent_call_id": parent_call_id,
+            "call_depth": call_depth,
         }
         self._history.append(history_entry)
 

--- a/src/oscilo/ScopeResolver.py
+++ b/src/oscilo/ScopeResolver.py
@@ -1,9 +1,32 @@
+LOCAL = 0
+GLOBAL = 1
+ENCLOSING = 2
+BUILTIN = 3
+NOT_FOUND = -1
+
+
 class ScopeResolver:
     def resolve(self, frame, var_name):
-        if var_name in frame.f_locals:
-            return 0, frame.f_locals.get(var_name)
-        
+        code = frame.f_code
+
+        # Statically declared local (co_cellvars covers locals captured by inner functions).
+        if var_name in code.co_varnames or var_name in code.co_cellvars:
+            # A declared local shadows outer scopes even while unbound (deleted or
+            # not yet assigned), so report NOT_FOUND instead of falling through.
+            if var_name in frame.f_locals:
+                return LOCAL, frame.f_locals.get(var_name)
+            return NOT_FOUND, None
+
+        # Free variable captured from an enclosing function scope.
+        if var_name in code.co_freevars:
+            if var_name in frame.f_locals:
+                return ENCLOSING, frame.f_locals.get(var_name)
+            return NOT_FOUND, None
+
         if var_name in frame.f_globals:
-            return 1, frame.f_globals.get(var_name)
-        
-        return -1, None
+            return GLOBAL, frame.f_globals.get(var_name)
+
+        if var_name in frame.f_builtins:
+            return BUILTIN, frame.f_builtins.get(var_name)
+
+        return NOT_FOUND, None

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -5,7 +5,9 @@ from .VariableTracker import VariableTracker
 
 LOCAL = 0
 GLOBAL = 1
-TRACKABLE_DOMAINS = (LOCAL, GLOBAL)
+ENCLOSING = 2
+BUILTIN = 3
+TRACKABLE_DOMAINS = (LOCAL, GLOBAL, ENCLOSING)
 BUFFERED_EVENTS = ("init", "updated", "deleted")
 DELETED_EVENT = "deleted"
 
@@ -200,7 +202,7 @@ class TraceDispatcher:
         return self._trace_lines
 
     def _should_skip_tracker(self, tracker, frame):
-        if tracker.domain == LOCAL and tracker.frame is not None:
+        if tracker.domain == LOCAL or tracker.domain == ENCLOSING and tracker.frame is not None:
             return frame is not tracker.frame
 
         if tracker.domain == GLOBAL and tracker.frame is not None:

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -15,6 +15,8 @@ class TraceDispatcher:
         self._is_tracing = False
         self._bufferRef = buffer
         self._resolver = ScopeResolver()
+        self._next_call_id = 1
+        self._frame_contexts = {}
 
     def setBuffer(self, buffer):
         self._bufferRef = buffer
@@ -29,6 +31,8 @@ class TraceDispatcher:
         )
         self._trackers.append(tracker)
 
+        context = self._ensure_call_context(frame)
+
         # Record the initial value when the variable already exists in scope.
         if domain in TRACKABLE_DOMAINS:
             self._append_buffer_event(
@@ -38,6 +42,9 @@ class TraceDispatcher:
                 domain,
                 self._get_frame_line(frame),
                 self._get_frame_func(frame),
+                self._get_context_call_id(context),
+                self._get_context_parent_call_id(context),
+                self._get_context_call_depth(context),
             )
 
         # Start global tracing once the first tracker is registered.
@@ -73,12 +80,14 @@ class TraceDispatcher:
 
         sys.settrace(None)
         self._is_tracing = False
+        self._frame_contexts.clear()
+        self._next_call_id = 1
 
-    def _append_buffer_event(self, varName, data, event_name, domain, line, func=None):
+    def _append_buffer_event(self, varName, data, event_name, domain, line, func=None, call_id=None, parent_call_id=None, call_depth=None):
         if self._bufferRef is None:
             return
 
-        self._bufferRef.append(varName, data, event_name, domain, line, func)
+        self._bufferRef.append(varName, data, event_name, domain, line, func, call_id, parent_call_id, call_depth, )
 
     def _get_frame_line(self, frame):
         if frame is None:
@@ -91,6 +100,52 @@ class TraceDispatcher:
             return None
 
         return frame.f_code.co_name
+
+    def _ensure_call_context(self, frame):
+        if frame is None:
+            return None
+
+        context = self._frame_contexts.get(frame)
+        if context is not None:
+            return context
+
+        parent_context = self._frame_contexts.get(frame.f_back)
+        parent_call_id = self._get_context_call_id(parent_context)
+        parent_depth = self._get_context_call_depth(parent_context)
+
+        context = {
+            "call_id": self._next_call_id,
+            "parent_call_id": parent_call_id,
+            "call_depth": parent_depth + 1 if parent_depth is not None else 1,
+        }
+        self._next_call_id += 1
+        self._frame_contexts[frame] = context
+
+        return context
+
+    def _clear_call_context(self, frame):
+        if frame is None:
+            return
+
+        self._frame_contexts.pop(frame, None)
+
+    def _get_context_call_id(self, context):
+        if context is None:
+            return None
+
+        return context["call_id"]
+
+    def _get_context_parent_call_id(self, context):
+        if context is None:
+            return None
+
+        return context["parent_call_id"]
+
+    def _get_context_call_depth(self, context):
+        if context is None:
+            return None
+
+        return context["call_depth"]
 
     def _get_event_data(self, tracker, event_name):
         # Deleted variables no longer have a value, so history stores None.
@@ -110,11 +165,13 @@ class TraceDispatcher:
         if event != "call":
             return
 
+        self._ensure_call_context(frame)
         return self._trace_lines
 
     def _trace_lines(self, frame, event, arg):
         if event not in ("line", "return"):
             return self._trace_lines
+        context = self._ensure_call_context(frame)
 
         # Iterate over a copy so tracker changes are safe during tracing.
         for tracker in list(self._trackers):
@@ -132,7 +189,13 @@ class TraceDispatcher:
                     self._get_logged_domain(tracker, event_name, domain),
                     frame.f_lineno,
                     self._get_frame_func(frame),
+                    self._get_context_call_id(context),
+                    self._get_context_parent_call_id(context),
+                    self._get_context_call_depth(context),
                 )
+
+        if event == "return":
+            self._clear_call_context(frame)
 
         return self._trace_lines
 

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -37,6 +37,7 @@ class TraceDispatcher:
                 "init",
                 domain,
                 self._get_frame_line(frame),
+                self._get_frame_func(frame),
             )
 
         # Start global tracing once the first tracker is registered.
@@ -73,17 +74,23 @@ class TraceDispatcher:
         sys.settrace(None)
         self._is_tracing = False
 
-    def _append_buffer_event(self, varName, data, event_name, domain, line):
+    def _append_buffer_event(self, varName, data, event_name, domain, line, func=None):
         if self._bufferRef is None:
             return
 
-        self._bufferRef.append(varName, data, event_name, domain, line)
+        self._bufferRef.append(varName, data, event_name, domain, line, func)
 
     def _get_frame_line(self, frame):
         if frame is None:
             return None
 
         return frame.f_lineno
+
+    def _get_frame_func(self, frame):
+        if frame is None:
+            return None
+
+        return frame.f_code.co_name
 
     def _get_event_data(self, tracker, event_name):
         # Deleted variables no longer have a value, so history stores None.
@@ -124,6 +131,7 @@ class TraceDispatcher:
                     event_name,
                     self._get_logged_domain(tracker, event_name, domain),
                     frame.f_lineno,
+                    self._get_frame_func(frame),
                 )
 
         return self._trace_lines

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -202,7 +202,7 @@ class TraceDispatcher:
         return self._trace_lines
 
     def _should_skip_tracker(self, tracker, frame):
-        if tracker.domain == LOCAL or tracker.domain == ENCLOSING and tracker.frame is not None:
+        if (tracker.domain == LOCAL or tracker.domain == ENCLOSING) and tracker.frame is not None:
             return frame is not tracker.frame
 
         if tracker.domain == GLOBAL and tracker.frame is not None:

--- a/src/oscilo/VariableTracker.py
+++ b/src/oscilo/VariableTracker.py
@@ -7,6 +7,8 @@ except ImportError:
 
 LOCAL = 0
 GLOBAL = 1
+ENCLOSING = 2
+BUILTIN = 3
 NOT_FOUND = -1
 
 INIT_EVENT = "init"
@@ -77,10 +79,10 @@ class VariableTracker:
         self._isActive = False
 
     def _get_current_value(self, frame, domain, varName):
-        if domain == LOCAL:
+        if domain == LOCAL or domain == ENCLOSING:
             return frame.f_locals.get(varName)
-
-        return frame.f_globals.get(varName)
+        elif domain == GLOBAL:
+            return frame.f_globals.get(varName)
 
     def _handle_missing_variable(self):
         if self._isActive:
@@ -97,7 +99,7 @@ class VariableTracker:
         if varName is None:
             varName = self.varName
 
-        if domain == NOT_FOUND:
+        if domain == NOT_FOUND or domain == BUILTIN:
             return self._handle_missing_variable()
 
         self.domain = domain

--- a/src/oscilo/oscilo_engine.c
+++ b/src/oscilo/oscilo_engine.c
@@ -2,17 +2,21 @@
 
 typedef enum {
     LOCAL = 0,
-    GLOBAL = 1
+    GLOBAL = 1,
+    ENCLOSING = 2,
+    BUILTIN = 3
 } ScopeType;
 
 static PyObject *get_scope_dict(PyObject *frame, ScopeType domain)
 {
     // Select the dictionary that should be inspected for the requested scope.
-    if (domain == LOCAL) {
+    if (domain == LOCAL || domain == ENCLOSING) {
         return PyFrame_GetLocals((PyFrameObject *)frame);
     }
-
-    return PyFrame_GetGlobals((PyFrameObject *)frame);
+    if (domain == GLOBAL) {
+        return PyFrame_GetGlobals((PyFrameObject *)frame);
+    }
+    return NULL;
 }
 
 static PyObject *get_reference_from_scope(PyObject *scope_dict, PyObject *key)

--- a/tests/test_oscilo_behavior.py
+++ b/tests/test_oscilo_behavior.py
@@ -140,6 +140,55 @@ class TestVMLBehavior(unittest.TestCase):
         self.assertEqual(second_logs[-1]["event"], "updated")
         self.assertEqual(second_logs[-1]["data"], "beta")
 
+    def test_func_field_identifies_function_scope_for_same_variable_name(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "func_scope.jsonl")
+            monitor = _Oscilo(filename)
+
+            def foo():
+                target = "foo-before"
+                monitor.register("target")
+
+                target = "foo-after"
+
+                # Keep tracing inside foo so the local update can be recorded.
+                checkpoint = "after foo update"
+                self.assertEqual(checkpoint, "after foo update")
+
+            def bar():
+                target = "bar-before"
+                monitor.register("target")
+
+                target = "bar-after"
+
+                # Keep tracing inside bar so the local update can be recorded.
+                checkpoint = "after bar update"
+                self.assertEqual(checkpoint, "after bar update")
+
+            foo()
+            bar()
+
+            logs = finalize_and_read_logs(monitor, filename)
+
+        foo_logs = [entry for entry in logs if entry["func"] == "foo"]
+        bar_logs = [entry for entry in logs if entry["func"] == "bar"]
+
+        self.assertGreaterEqual(len(foo_logs), 2)
+        self.assertGreaterEqual(len(bar_logs), 2)
+
+        self.assertEqual({entry["name"] for entry in foo_logs}, {"target"})
+        self.assertEqual({entry["name"] for entry in bar_logs}, {"target"})
+
+        self.assertEqual(foo_logs[0]["event"], "init")
+        self.assertEqual(foo_logs[0]["data"], "foo-before")
+        self.assertEqual(foo_logs[-1]["event"], "updated")
+        self.assertEqual(foo_logs[-1]["data"], "foo-after")
+
+        self.assertEqual(bar_logs[0]["event"], "init")
+        self.assertEqual(bar_logs[0]["data"], "bar-before")
+        self.assertEqual(bar_logs[-1]["event"], "updated")
+        self.assertEqual(bar_logs[-1]["data"], "bar-after")
+    
     def test_log_entries_use_jsonl_schema(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             filename = os.path.join(temp_dir, "schema.jsonl")
@@ -164,6 +213,7 @@ class TestVMLBehavior(unittest.TestCase):
             self.assertIn(entry["event"], TRACKING_EVENTS)
             self.assertIn(entry["domain"], TRACKING_DOMAINS)
             self.assertTrue(entry["line"] is None or isinstance(entry["line"], int))
+            self.assertTrue(entry["func"] is None or isinstance(entry["func"], str))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_oscilo_behavior.py
+++ b/tests/test_oscilo_behavior.py
@@ -216,6 +216,7 @@ class TestVMLBehavior(unittest.TestCase):
             self.assertTrue(entry["call_id"] is None or isinstance(entry["call_id"], int))
             self.assertTrue(entry["parent_call_id"] is None or isinstance(entry["parent_call_id"], int))
             self.assertTrue(entry["call_depth"] is None or isinstance(entry["call_depth"], int))
+
     def test_call_context_identifies_recursive_function_calls(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             filename = os.path.join(temp_dir, "recursive_context.jsonl")
@@ -250,6 +251,50 @@ class TestVMLBehavior(unittest.TestCase):
         self.assertIsNone(parent_call_ids[0])
         self.assertEqual(parent_call_ids[1], call_ids[0])
         self.assertEqual(parent_call_ids[2], call_ids[1])
+
+    def test_call_context_distinguishes_sibling_recursive_calls(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "sibling_recursive_context.jsonl")
+            monitor = _Oscilo(filename)
+
+            def fib(n):
+                monitor.register("n")
+
+                if n <= 1:
+                    return n
+
+                return fib(n - 1) + fib(n - 2)
+
+            self.assertEqual(fib(3), 2)
+
+            logs = finalize_and_read_logs(monitor, filename)
+
+        init_logs = [
+            entry
+            for entry in logs
+            if entry["name"] == "n" and entry["event"] == "init"
+        ]
+
+        self.assertEqual([entry["data"] for entry in init_logs], [3, 2, 1, 0, 1])
+
+        call_ids = [entry["call_id"] for entry in init_logs]
+        parent_call_ids = [entry["parent_call_id"] for entry in init_logs]
+
+        self.assertEqual(len(call_ids), 5)
+        self.assertEqual(len(set(call_ids)), 5)
+
+        root_call_id = call_ids[0]
+        left_child_call_id = call_ids[1]
+        right_child_call_id = call_ids[4]
+
+        self.assertIsNone(parent_call_ids[0])
+        self.assertEqual(parent_call_ids[1], root_call_id)
+        self.assertEqual(parent_call_ids[2], left_child_call_id)
+        self.assertEqual(parent_call_ids[3], left_child_call_id)
+        self.assertEqual(parent_call_ids[4], root_call_id)
+
+        self.assertNotEqual(left_child_call_id, right_child_call_id)
+        self.assertEqual([entry["call_depth"] for entry in init_logs], [1, 2, 3, 3, 2])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_oscilo_behavior.py
+++ b/tests/test_oscilo_behavior.py
@@ -5,7 +5,7 @@ import unittest
 
 from oscilo._core import _Oscilo
 
-EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func"}
+EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
 
@@ -144,7 +144,6 @@ class TestVMLBehavior(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             filename = os.path.join(temp_dir, "func_scope.jsonl")
             monitor = _Oscilo(filename)
-
             def foo():
                 target = "foo-before"
                 monitor.register("target")
@@ -214,6 +213,43 @@ class TestVMLBehavior(unittest.TestCase):
             self.assertIn(entry["domain"], TRACKING_DOMAINS)
             self.assertTrue(entry["line"] is None or isinstance(entry["line"], int))
             self.assertTrue(entry["func"] is None or isinstance(entry["func"], str))
+            self.assertTrue(entry["call_id"] is None or isinstance(entry["call_id"], int))
+            self.assertTrue(entry["parent_call_id"] is None or isinstance(entry["parent_call_id"], int))
+            self.assertTrue(entry["call_depth"] is None or isinstance(entry["call_depth"], int))
+    def test_call_context_identifies_recursive_function_calls(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "recursive_context.jsonl")
+            monitor = _Oscilo(filename)
+
+            def factorial(n):
+                monitor.register("n")
+
+                if n <= 1:
+                    return 1
+
+                return n * factorial(n - 1)
+
+            self.assertEqual(factorial(3), 6)
+
+            logs = finalize_and_read_logs(monitor, filename)
+
+        init_logs = [
+            entry
+            for entry in logs
+            if entry["name"] == "n" and entry["event"] == "init"
+        ]
+
+        self.assertEqual([entry["data"] for entry in init_logs], [3, 2, 1])
+        self.assertEqual([entry["func"] for entry in init_logs], ["factorial", "factorial", "factorial"])
+        self.assertEqual([entry["call_depth"] for entry in init_logs], [1, 2, 3])
+
+        call_ids = [entry["call_id"] for entry in init_logs]
+        parent_call_ids = [entry["parent_call_id"] for entry in init_logs]
+
+        self.assertEqual(len(set(call_ids)), 3)
+        self.assertIsNone(parent_call_ids[0])
+        self.assertEqual(parent_call_ids[1], call_ids[0])
+        self.assertEqual(parent_call_ids[2], call_ids[1])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_oscilo_behavior.py
+++ b/tests/test_oscilo_behavior.py
@@ -5,7 +5,7 @@ import unittest
 
 from oscilo._core import _Oscilo
 
-EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line"}
+EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func"}
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
 

--- a/tests/test_oscilo_components.py
+++ b/tests/test_oscilo_components.py
@@ -56,8 +56,8 @@ class TestVMlogComponents(unittest.TestCase):
         self.assertEqual(
             history,
             [
-                {"name": "A", "data": 10, "event": "init", "domain": "LOCAL", "line": 1, "func": None},
-                {"name": "A", "data": 20, "event": "updated", "domain": "LOCAL", "line": 2, "func": None},
+                {"name": "A", "data": 10, "event": "init", "domain": "LOCAL", "line": 1, "func": None, "call_id": None, "parent_call_id": None, "call_depth": None,},
+                {"name": "A", "data": 20, "event": "updated", "domain": "LOCAL", "line": 2, "func": None, "call_id": None, "parent_call_id": None, "call_depth": None,},
             ],
         )
 

--- a/tests/test_oscilo_components.py
+++ b/tests/test_oscilo_components.py
@@ -56,8 +56,8 @@ class TestVMlogComponents(unittest.TestCase):
         self.assertEqual(
             history,
             [
-                {"name": "A", "data": 10, "event": "init", "domain": "LOCAL", "line": 1},
-                {"name": "A", "data": 20, "event": "updated", "domain": "LOCAL", "line": 2},
+                {"name": "A", "data": 10, "event": "init", "domain": "LOCAL", "line": 1, "func": None},
+                {"name": "A", "data": 20, "event": "updated", "domain": "LOCAL", "line": 2, "func": None},
             ],
         )
 

--- a/tests/test_oscilo_process_lifecycle.py
+++ b/tests/test_oscilo_process_lifecycle.py
@@ -10,7 +10,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
 DEFAULT_LOG_NAME = "ocilo.jsonl"
-EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func"}
+EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
 

--- a/tests/test_oscilo_process_lifecycle.py
+++ b/tests/test_oscilo_process_lifecycle.py
@@ -10,7 +10,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
 DEFAULT_LOG_NAME = "ocilo.jsonl"
-EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line"}
+EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func"}
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
 

--- a/tests/test_scope_resolver_legb.py
+++ b/tests/test_scope_resolver_legb.py
@@ -1,0 +1,125 @@
+import sys
+import unittest
+
+from oscilo.ScopeResolver import ScopeResolver
+
+LOCAL = 0
+GLOBAL = 1
+ENCLOSING = 2
+BUILTIN = 3
+NOT_FOUND = -1
+
+TEST_LEGB_GLOBAL = "global-value"
+
+class TestScopeResolverLEGB(unittest.TestCase):
+    def setUp(self):
+        self.resolver = ScopeResolver()
+
+    def test_captured_local_is_classified_as_local(self):
+        captured = "cell-value"
+
+        # Referencing the variable from an inner function moves it to co_cellvars,
+        # but it must still be classified as LOCAL in the defining frame.
+        def inner():
+            return captured
+
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "captured")
+
+        self.assertEqual(domain, LOCAL)
+        self.assertEqual(value, "cell-value")
+
+    def test_free_variable_is_classified_as_enclosing(self):
+        enclosing_value = "enclosing-value"
+
+        def inner():
+            frame = sys._getframe()
+            result = self.resolver.resolve(frame, "enclosing_value")
+            # Reference the name so it stays a free variable of this code object.
+            self.assertEqual(enclosing_value, "enclosing-value")
+            return result
+
+        domain, value = inner()
+
+        self.assertEqual(domain, ENCLOSING)
+        self.assertEqual(value, "enclosing-value")
+
+    def test_module_variable_is_classified_as_global(self):
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "TEST_LEGB_GLOBAL")
+
+        self.assertEqual(domain, GLOBAL)
+        self.assertEqual(value, "global-value")
+
+    def test_builtin_name_is_classified_as_builtin(self):
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "len")
+
+        self.assertEqual(domain, BUILTIN)
+        self.assertIs(value, len)
+
+    def test_local_shadows_builtin(self):
+        len = "shadowed-builtin"
+
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "len")
+
+        self.assertEqual(domain, LOCAL)
+        self.assertEqual(value, "shadowed-builtin")
+
+    def test_enclosing_shadows_global(self):
+        TEST_LEGB_GLOBAL = "enclosing-value"
+
+        def inner():
+            frame = sys._getframe()
+            result = self.resolver.resolve(frame, "TEST_LEGB_GLOBAL")
+            self.assertEqual(TEST_LEGB_GLOBAL, "enclosing-value")
+            return result
+
+        domain, value = inner()
+
+        self.assertEqual(domain, ENCLOSING)
+        self.assertEqual(value, "enclosing-value")
+
+    def test_declared_local_shadows_global_even_while_unbound(self):
+        frame = sys._getframe()
+
+        # The assignment below makes the name a declared local for this whole
+        # function, so resolving before it binds must not fall back to the global.
+        domain, value = self.resolver.resolve(frame, "TEST_LEGB_GLOBAL")
+
+        self.assertEqual(domain, NOT_FOUND)
+        self.assertIsNone(value)
+
+        TEST_LEGB_GLOBAL = "local-value"
+        self.assertEqual(TEST_LEGB_GLOBAL, "local-value")
+
+    def test_deleted_local_is_not_found(self):
+        target = "local-value"
+        del target
+
+        frame = sys._getframe()
+        domain, value = self.resolver.resolve(frame, "target")
+
+        self.assertEqual(domain, NOT_FOUND)
+        self.assertIsNone(value)
+
+    def test_unbound_free_variable_is_not_found(self):
+        captured = "will-be-deleted"
+
+        def inner():
+            frame = sys._getframe()
+            result = self.resolver.resolve(frame, "captured")
+            # Reference the name so it stays a free variable of this code object.
+            if False:
+                captured
+            return result
+
+        del captured
+        domain, value = inner()
+
+        self.assertEqual(domain, NOT_FOUND)
+        self.assertIsNone(value)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- 변수 추적 로그가 변수 이름만으로 식별되던 한계를 보완하기 위해 함수 정보, 호출 컨텍스트, LEGB 기반 스코프 정보를 로그에 함께 기록하도록 확장했다.
- 동일한 변수명이라도 함수 스코프, 재귀 호출 인스턴스, enclosing scope 여부에 따라 구분할 수 있도록 추적 정확도를 개선했다.

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] 로그 엔트리에 `func`, `call_id`, `parent_call_id`, `call_depth` 필드를 추가하여 변수 변경이 발생한 함수와 호출 인스턴스를 식별할 수 있도록 했다.
- [x] `TraceDispatcher`에서 frame 기반 함수명 추출과 호출 컨텍스트 관리를 추가하여 재귀 및 형제 재귀 호출을 구분할 수 있도록 했다.
- [x] `ScopeResolver`를 LEGB 규칙 기반으로 확장하여 `LOCAL`, `GLOBAL`, `ENCLOSING`, `BUILTIN` 스코프를 판별하도록 했다.
- [x] `VariableTracker`, C 확장 엔진, `HistoryBuffer`가 확장된 스코프 및 로그 필드를 처리할 수 있도록 연동했다.
- [x] 함수 스코프 구분, 일직선 재귀, 형제 재귀, LEGB 스코프 판별을 검증하는 테스트를 추가다.

## Issue Link
<!-- Link any related issues below. e.g., Closes #12 -->
- Closes #

## Screenshots / Videos (Optional)
<!-- Attach any visual evidence, mockups, or demos if there are UI/UX changes. -->

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.