### PR TITLE
Dynamic versioning by git tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,26 +4,60 @@ on:
     types: [published]
 
 jobs:
-  # 1. Building C Extension
+  # 1. Build the sdist first so it carries the setuptools-scm resolved version.
+  #    Wheels are then built from this sdist, so the C-extension build never needs
+  #    git access inside the cibuildwheel containers.
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs full history + tags to resolve the version
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  # 2. Build the C-extension wheels from the sdist produced above. The sdist
+  #    already embeds the resolved version (PKG-INFO + _version.py), so no git
+  #    metadata is required inside the build containers.
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    needs: [build_sdist]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Set up QEMU
         if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist
+
+      - name: Locate sdist
+        id: sdist
+        shell: bash
+        run: echo "path=$(ls dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+
       - name: Build wheels via cibuildwheel
         uses: pypa/cibuildwheel@v2.22.0
+        with:
+          package-dir: ${{ steps.sdist.outputs.path }}
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -34,23 +68,6 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
-
-  # Building sdist
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build sdist
-        run: pipx run build --sdist
-
-      - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cibw-sdist
-          path: dist/*.tar.gz
 
   upload_pypi:
     name: Upload to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs full history + tags to resolve the version
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 oscilo.egg-info/
 
 __pycache__/
+
+# setuptools-scm generated version file
+src/oscilo/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oscilo"
-version = "2.0.0"
+dynamic = ["version"]
 authors = [{name = "sdkurjnk", email = "sdkurjnk@naver.com"}]
 license = "MIT"
 description = "Zero-invasive Python variable-change tracker powered by a C-extension trace engine with automatic scope resolution and JSONL history output"
@@ -28,3 +28,6 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools_scm]
+version_file = "src/oscilo/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- 패키지 버전을 하드코딩(`2.0.0`) 대신 **git 태그 기반**으로 자동 관리하도록 setuptools-scm을 도입
- 향후 버전을 0.1.0으로 재시작할 예정

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] `pyproject.toml`: 정적 `version` 제거 → `dynamic = ["version"]` + `[tool.setuptools_scm]` 설정, build-system에 `setuptools-scm>=8` 추가 (버전은 v0.1.0 태그 발행 시점부터 적용)
- [x] CI(`test.yml`): checkout에 `fetch-depth: 0` 추가 — setuptools-scm이 태그·전체 히스토리를 읽도록
- [x] CD(`publish.yml`): sdist를 먼저 빌드해 버전을 고정하고, 휠은 그 sdist에서 빌드 — cibuildwheel 컨테이너 안에서 git 없이도 버전 해석 가능
- [x] 만약 배포 후 개발이 진행된 경우, setuptools-scm은 가장가까운태그 이후로 커밋이 쌓이면 "다음 버전의 개발판" 형태로 만든다.
       {다음버전}.dev{태그이후_커밋수}+g{짧은해시}[.d{날짜}]

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.