### PR TITLE
Feature/tracker selection

### DIFF
--- a/src/oscilo/CallContext.py
+++ b/src/oscilo/CallContext.py
@@ -1,0 +1,136 @@
+class CallContextManager:
+    def __init__(self):
+        self._next_call_id = 1
+        self._contexts = {}
+        self._cleanup_traces = {}
+
+    def ensure_context(self, frame):
+        if frame is None:
+            return None
+
+        existing_context = self._contexts.get(frame)
+        if existing_context is not None:
+            return existing_context
+
+        missing_frames = []
+        current_frame = frame
+
+        # Walk toward an already known logging ancestor. Frames between that
+        # ancestor and the requested frame must also receive contexts so parent
+        # links and call depth remain continuous.
+        while (
+            current_frame is not None
+            and current_frame not in self._contexts
+        ):
+            missing_frames.append(current_frame)
+            current_frame = current_frame.f_back
+
+        if current_frame is None:
+            # No logging ancestor exists. The requested frame becomes the root of
+            # a new logging chain rather than pulling unrelated interpreter and
+            # test-runner frames into the context tree.
+            return self._create_context(
+                frame,
+                parent_context=None,
+            )
+
+        parent_context = self._contexts[current_frame]
+
+        for missing_frame in reversed(missing_frames):
+            context = self._create_context(
+                missing_frame,
+                parent_context,
+            )
+
+            # The requested frame is relevant and its normal return tracer will
+            # call on_return(). Only automatically created gap frames need the
+            # lightweight return-only cleanup tracer.
+            if missing_frame is not frame:
+                self._attach_return_cleanup(missing_frame)
+
+            parent_context = context
+
+        return self._contexts[frame]
+
+    def on_return(self, frame):
+        if frame is None:
+            return
+
+        self._contexts.pop(frame, None)
+        self._restore_cleanup_trace(frame)
+
+    def clear(self):
+        for frame in list(self._cleanup_traces):
+            self._restore_cleanup_trace(frame)
+
+        self._contexts.clear()
+        self._next_call_id = 1
+
+    def _create_context(self, frame, parent_context):
+        parent_call_id = None
+        call_depth = 1
+
+        if parent_context is not None:
+            parent_call_id = parent_context["call_id"]
+            call_depth = parent_context["call_depth"] + 1
+
+        context = {
+            "call_id": self._next_call_id,
+            "parent_call_id": parent_call_id,
+            "call_depth": call_depth,
+        }
+
+        self._next_call_id += 1
+        self._contexts[frame] = context
+
+        return context
+
+    def _attach_return_cleanup(self, frame):
+        if frame in self._cleanup_traces:
+            return
+
+        # A frame with an existing local tracer is expected to be relevant. Its
+        # normal return path must call on_return(), so do not replace that tracer.
+        previous_trace = getattr(frame, "f_trace", None)
+        if previous_trace is not None:
+            return
+
+        previous_trace_lines = getattr(
+            frame,
+            "f_trace_lines",
+            True,
+        )
+
+        def cleanup_trace(current_frame, event, arg):
+            if event == "return":
+                self.on_return(current_frame)
+                return None
+
+            return cleanup_trace
+
+        frame.f_trace = cleanup_trace
+        frame.f_trace_lines = False
+
+        self._cleanup_traces[frame] = {
+            "installed_trace": cleanup_trace,
+            "previous_trace": previous_trace,
+            "previous_trace_lines": previous_trace_lines,
+        }
+
+    def _restore_cleanup_trace(self, frame):
+        cleanup_state = self._cleanup_traces.pop(
+            frame,
+            None,
+        )
+
+        if cleanup_state is None:
+            return
+
+        installed_trace = cleanup_state["installed_trace"]
+
+        if getattr(frame, "f_trace", None) is installed_trace:
+            frame.f_trace = cleanup_state["previous_trace"]
+
+        frame.f_trace_lines = cleanup_state[
+            "previous_trace_lines"
+        ]

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -58,9 +58,9 @@ class TraceDispatcher:
             or varName in code.co_freevars
         )
 
-    def register(self, varName, domain=None, value=None, frame=None):
+    def register(self, varName, frame=None):
         if frame is None:
-            tracker = VariableTracker(varName, domain=domain)
+            tracker = VariableTracker(varName)
             self._trackers.append(tracker)
             self._frame_cache.clear()
             self._start_tracing()

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -1,5 +1,6 @@
 import sys
 
+from .CallContext import CallContextManager
 from .ScopeResolver import ScopeResolver
 from .VariableTracker import VariableTracker
 
@@ -17,50 +18,108 @@ class TraceDispatcher:
         self._is_tracing = False
         self._bufferRef = buffer
         self._resolver = ScopeResolver()
-        self._next_call_id = 1
-        self._frame_contexts = {}
+        self._context_manager = CallContextManager()
+
+        # Cache of "which trackers matter for this code object", keyed by
+        # frame.f_code so unrelated frames can skip line tracing entirely.
+        self._frame_cache = {}
+
+        # Registration-time scope identity for each tracker, kept on the
+        # dispatcher (never on the tracker or as a live frame reference) so a
+        # tracker only ever applies to the exact function or module it was
+        # registered against.
+        self._tracker_codes = {}
+        self._tracker_globals = {}
+
+        # Dedup keys so registering the same variable/scope twice (e.g. once
+        # per recursive call) reuses the existing tracker instead of
+        # proliferating one per call.
+        self._registered_local = {}
+        self._registered_global = {}
+
+        # GLOBAL variables have a single timeline shared by every frame that
+        # observes them, so their previous state lives here instead of in any
+        # one frame's state.
+        self._global_states = {}
+
+        # Per-active-frame local/enclosing state, keyed by the frame object
+        # itself. Entries are removed on that frame's return event and the
+        # dict is cleared on stop(), so nothing here outlives the frame.
+        self._frame_states = {}
 
     def setBuffer(self, buffer):
         self._bufferRef = buffer
 
-    def register(self, varName, domain=None, value=None, frame=None):
-        tracker = VariableTracker(
-            varName,
-            domain=domain,
-            value=value,
-            exists=domain in TRACKABLE_DOMAINS,
-            frame=frame,
+    def _is_local_name(self, frame, varName):
+        code = frame.f_code
+        return (
+            varName in code.co_varnames
+            or varName in code.co_cellvars
+            or varName in code.co_freevars
         )
-        self._trackers.append(tracker)
 
-        context = self._ensure_call_context(frame)
+    def register(self, varName, domain=None, value=None, frame=None):
+        if frame is None:
+            tracker = VariableTracker(varName, domain=domain)
+            self._trackers.append(tracker)
+            self._frame_cache.clear()
+            self._start_tracing()
+            return tracker
 
-        # Record the initial value when the variable already exists in scope.
-        if domain in TRACKABLE_DOMAINS:
-            self._append_buffer_event(
-                varName,
-                tracker.get_snapshot(),
-                "init",
-                domain,
-                self._get_frame_line(frame),
-                self._get_frame_func(frame),
-                self._get_context_call_id(context),
-                self._get_context_parent_call_id(context),
-                self._get_context_call_depth(context),
-            )
+        resolved_domain, _ = self._resolver.resolve(frame, varName)
+        is_local = self._is_local_name(frame, varName)
+
+        if is_local:
+            dedup_key = (varName, frame.f_code)
+            tracker = self._registered_local.get(dedup_key)
+        else:
+            dedup_key = (varName, id(frame.f_globals))
+            tracker = self._registered_global.get(dedup_key)
+
+        if tracker is None:
+            tracker = VariableTracker(varName, domain=resolved_domain)
+            self._trackers.append(tracker)
+
+            if is_local:
+                self._registered_local[dedup_key] = tracker
+                self._tracker_codes[tracker] = frame.f_code
+            else:
+                self._registered_global[dedup_key] = tracker
+                self._tracker_globals[tracker] = frame.f_globals
+
+            # A new tracker can change which trackers apply to any code
+            # object, so the relevance cache can no longer be trusted.
+            self._frame_cache.clear()
 
         # Start global tracing once the first tracker is registered.
         self._start_tracing()
 
-        # Attach line tracing to the registration frame so local changes are captured.
-        if frame is not None:
-            frame.f_trace = self._trace_lines
+        # The registration frame's "call" event already happened before this
+        # tracker existed, so line tracing must be attached here explicitly
+        # (or reused if already attached by an earlier registration/call).
+        frame_state = self._ensure_frame_tracking(frame)
+
+        if is_local:
+            self._check_and_log(frame, tracker, frame_state, varName, resolved_domain)
+        else:
+            self._check_and_log(frame, tracker, self._global_states, tracker, resolved_domain)
 
         return tracker
 
     def unregister(self, tracker):
         if tracker in self._trackers:
             self._trackers.remove(tracker)
+
+        code = self._tracker_codes.pop(tracker, None)
+        if code is not None:
+            self._registered_local.pop((tracker.varName, code), None)
+
+        globals_dict = self._tracker_globals.pop(tracker, None)
+        if globals_dict is not None:
+            self._registered_global.pop((tracker.varName, id(globals_dict)), None)
+
+        self._global_states.pop(tracker, None)
+        self._frame_cache.clear()
 
         if not self._trackers:
             self._stop_tracing()
@@ -82,8 +141,14 @@ class TraceDispatcher:
 
         sys.settrace(None)
         self._is_tracing = False
-        self._frame_contexts.clear()
-        self._next_call_id = 1
+        self._frame_cache.clear()
+        self._frame_states.clear()
+        self._tracker_codes.clear()
+        self._tracker_globals.clear()
+        self._registered_local.clear()
+        self._registered_global.clear()
+        self._global_states.clear()
+        self._context_manager.clear()
 
     def _append_buffer_event(self, varName, data, event_name, domain, line, func=None, call_id=None, parent_call_id=None, call_depth=None):
         if self._bufferRef is None:
@@ -103,34 +168,6 @@ class TraceDispatcher:
 
         return frame.f_code.co_name
 
-    def _ensure_call_context(self, frame):
-        if frame is None:
-            return None
-
-        context = self._frame_contexts.get(frame)
-        if context is not None:
-            return context
-
-        parent_context = self._frame_contexts.get(frame.f_back)
-        parent_call_id = self._get_context_call_id(parent_context)
-        parent_depth = self._get_context_call_depth(parent_context)
-
-        context = {
-            "call_id": self._next_call_id,
-            "parent_call_id": parent_call_id,
-            "call_depth": parent_depth + 1 if parent_depth is not None else 1,
-        }
-        self._next_call_id += 1
-        self._frame_contexts[frame] = context
-
-        return context
-
-    def _clear_call_context(self, frame):
-        if frame is None:
-            return
-
-        self._frame_contexts.pop(frame, None)
-
     def _get_context_call_id(self, context):
         if context is None:
             return None
@@ -149,13 +186,6 @@ class TraceDispatcher:
 
         return context["call_depth"]
 
-    def _get_event_data(self, tracker, event_name):
-        # Deleted variables no longer have a value, so history stores None.
-        if event_name == DELETED_EVENT:
-            return None
-
-        return tracker.get_snapshot()
-
     def _get_logged_domain(self, tracker, event_name, resolved_domain):
         # Preserve the previous scope when deletion makes the variable unresolvable.
         if event_name == DELETED_EVENT and resolved_domain not in TRACKABLE_DOMAINS:
@@ -163,49 +193,111 @@ class TraceDispatcher:
 
         return resolved_domain
 
+    def _log_event(self, frame, tracker, event_name, new_state, domain):
+        # Only touch call-context bookkeeping when there is something to log.
+        context = self._context_manager.ensure_context(frame)
+
+        self._append_buffer_event(
+            tracker.varName,
+            tracker.get_snapshot(new_state),
+            event_name,
+            self._get_logged_domain(tracker, event_name, domain),
+            self._get_frame_line(frame),
+            self._get_frame_func(frame),
+            self._get_context_call_id(context),
+            self._get_context_parent_call_id(context),
+            self._get_context_call_depth(context),
+        )
+
+    def _check_and_log(self, frame, tracker, storage, key, domain):
+        prev_state = storage.get(key)
+        event_name, new_state = tracker.check(frame, domain, tracker.varName, prev_state)
+
+        if new_state is None:
+            storage.pop(key, None)
+        else:
+            storage[key] = new_state
+
+        if event_name in BUFFERED_EVENTS:
+            self._log_event(frame, tracker, event_name, new_state, domain)
+
+        return event_name, new_state
+
+    def _get_cache_entry(self, frame):
+        code = frame.f_code
+        entry = self._frame_cache.get(code)
+        if entry is not None:
+            return entry
+
+        names = set(code.co_varnames) | set(code.co_cellvars) | set(code.co_freevars)
+        local_candidates = [tracker for tracker in self._trackers if tracker.varName in names]
+        global_candidates = [tracker for tracker in self._trackers if tracker.varName not in names]
+
+        entry = (local_candidates, global_candidates, frame.f_globals)
+        self._frame_cache[code] = entry
+        return entry
+
+    def _relevant_for(self, frame):
+        local_candidates, global_candidates, entry_globals = self._get_cache_entry(frame)
+
+        local_relevant = [
+            tracker for tracker in local_candidates
+            if self._tracker_codes.get(tracker) is frame.f_code
+        ]
+
+        global_relevant = []
+        if global_candidates and frame.f_globals is entry_globals:
+            global_relevant = [
+                tracker for tracker in global_candidates
+                if self._tracker_globals.get(tracker) is frame.f_globals
+            ]
+
+        return local_relevant, global_relevant
+
+    def _process_frame(self, frame, frame_state):
+        local_relevant, global_relevant = self._relevant_for(frame)
+
+        for tracker in local_relevant:
+            domain, _ = self._resolver.resolve(frame, tracker.varName)
+            self._check_and_log(frame, tracker, frame_state, tracker.varName, domain)
+
+        for tracker in global_relevant:
+            domain, _ = self._resolver.resolve(frame, tracker.varName)
+            self._check_and_log(frame, tracker, self._global_states, tracker, domain)
+
+    def _make_line_tracer(self, frame_state):
+        def trace_lines(current_frame, current_event, current_arg):
+            if current_event not in ("line", "return"):
+                return trace_lines
+
+            self._process_frame(current_frame, frame_state)
+
+            if current_event == "return":
+                self._context_manager.on_return(current_frame)
+                self._frame_states.pop(current_frame, None)
+                return None
+
+            return trace_lines
+
+        return trace_lines
+
+    def _ensure_frame_tracking(self, frame):
+        frame_state = self._frame_states.get(frame)
+        if frame_state is not None:
+            return frame_state
+
+        frame_state = {}
+        self._frame_states[frame] = frame_state
+        frame.f_trace = self._make_line_tracer(frame_state)
+        return frame_state
+
     def _trace_calls(self, frame, event, arg):
         if event != "call":
-            return
+            return None
 
-        self._ensure_call_context(frame)
-        return self._trace_lines
+        local_relevant, global_relevant = self._relevant_for(frame)
+        if not local_relevant and not global_relevant:
+            return None
 
-    def _trace_lines(self, frame, event, arg):
-        if event not in ("line", "return"):
-            return self._trace_lines
-        context = self._ensure_call_context(frame)
-
-        # Iterate over a copy so tracker changes are safe during tracing.
-        for tracker in list(self._trackers):
-            if self._should_skip_tracker(tracker, frame):
-                continue
-
-            domain, _ = self._resolver.resolve(frame, tracker.varName)
-            event_name = tracker.check(frame, domain, tracker.varName)
-
-            if event_name in BUFFERED_EVENTS:
-                self._append_buffer_event(
-                    tracker.varName,
-                    self._get_event_data(tracker, event_name),
-                    event_name,
-                    self._get_logged_domain(tracker, event_name, domain),
-                    frame.f_lineno,
-                    self._get_frame_func(frame),
-                    self._get_context_call_id(context),
-                    self._get_context_parent_call_id(context),
-                    self._get_context_call_depth(context),
-                )
-
-        if event == "return":
-            self._clear_call_context(frame)
-
-        return self._trace_lines
-
-    def _should_skip_tracker(self, tracker, frame):
-        if (tracker.domain == LOCAL or tracker.domain == ENCLOSING) and tracker.frame is not None:
-            return frame is not tracker.frame
-
-        if tracker.domain == GLOBAL and tracker.frame is not None:
-            return frame.f_globals is not tracker.frame.f_globals
-
-        return False
+        self._ensure_frame_tracking(frame)
+        return frame.f_trace

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -58,13 +58,9 @@ class TraceDispatcher:
             or varName in code.co_freevars
         )
 
-    def register(self, varName, frame=None):
+    def register(self, varName, frame):
         if frame is None:
-            tracker = VariableTracker(varName)
-            self._trackers.append(tracker)
-            self._frame_cache.clear()
-            self._start_tracing()
-            return tracker
+            raise ValueError("frame is required to register a variable tracker")
 
         resolved_domain, _ = self._resolver.resolve(frame, varName)
         is_local = self._is_local_name(frame, varName)

--- a/src/oscilo/VariableTracker.py
+++ b/src/oscilo/VariableTracker.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     raise RuntimeError("oscilo_engine C extension is not found.")
 
+
 LOCAL = 0
 GLOBAL = 1
 ENCLOSING = 2
@@ -16,8 +17,6 @@ UPDATED_EVENT = "updated"
 DELETED_EVENT = "deleted"
 NOT_FOUND_EVENT = "not_found"
 NO_CHANGE_EVENT = "no_change"
-
-_ATOMIC_TYPES = (int, float, bool, str, bytes, type(None))
 
 _FRAME_STATE_IMMUTABLE_TYPES = (
     int,
@@ -31,53 +30,11 @@ _FRAME_STATE_IMMUTABLE_TYPES = (
     type(None),
 )
 
-_STATE_UNSET = object()
 
 class VariableTracker:
-    def __init__(self, varName, domain=None, value=None, exists=False, frame=None):
+    def __init__(self, varName, domain=None):
         self.varName = varName
         self.domain = domain
-        self.frame = frame
-        self._lastRef = None
-        self._lastCopy = None
-        self._lastSnapshot = None
-        self._isActive = False
-
-        if exists:
-            self._store(value)
-            self._isActive = True
-
-    def _make_snapshot(self, value):
-        # Atomic values are safe to reuse because they cannot be mutated in place.
-        if isinstance(value, _ATOMIC_TYPES):
-            return value
-
-        value_type = type(value)
-
-        # Handle common containers directly to avoid unnecessary deepcopy cost.
-        if value_type is list:
-            return [self._make_snapshot(item) for item in value]
-
-        if value_type is dict:
-            return {
-                self._make_snapshot(key): self._make_snapshot(item)
-                for key, item in value.items()
-            }
-
-        if value_type is set:
-            return {self._make_snapshot(item) for item in value}
-
-        if value_type is frozenset:
-            return frozenset(self._make_snapshot(item) for item in value)
-
-        if value_type is tuple:
-            return tuple(self._make_snapshot(item) for item in value)
-
-        # Fall back to deepcopy for custom objects, then repr if copying fails.
-        try:
-            return copy.deepcopy(value)
-        except Exception:
-            return repr(value)
 
     def _make_state(self, value):
         # Frame state always keeps the current live reference. Only values whose
@@ -92,38 +49,16 @@ class VariableTracker:
             "copy": snapshot,
         }
 
-    def _store(self, value):
-        # Store both a live reference and a snapshot for native change detection.
-        snapshot = self._make_snapshot(value)
-        self._lastRef = value
-        self._lastCopy = snapshot
-        self._lastSnapshot = snapshot
-
-    def _clear_state(self):
-        self._lastRef = None
-        self._lastCopy = None
-        self._lastSnapshot = None
-        self._isActive = False
-
     def _get_current_value(self, frame, domain, varName):
         if domain == LOCAL or domain == ENCLOSING:
             return frame.f_locals.get(varName)
-        elif domain == GLOBAL:
+
+        if domain == GLOBAL:
             return frame.f_globals.get(varName)
 
-    def _handle_missing_variable(self):
-        if self._isActive:
-            self._clear_state()
-            return DELETED_EVENT
+        return None
 
-        return NOT_FOUND_EVENT
-
-    def get_snapshot(self, state=_STATE_UNSET):
-        # Keep the existing no-argument path until the dispatcher is migrated to
-        # frame-local state in the following stages.
-        if state is _STATE_UNSET:
-            return self._make_snapshot(self._lastSnapshot)
-
+    def get_snapshot(self, state):
         if state is None:
             return None
 
@@ -133,38 +68,16 @@ class VariableTracker:
         # Do not expose the stored mutable snapshot directly to callers.
         return copy.deepcopy(state["copy"])
 
-    def _check_with_instance_state(self, frame, domain, varName):
-        # Temporary compatibility path for the current dispatcher. This path is
-        # removed after the dispatcher migrates to frame-local state.
-        if domain == NOT_FOUND or domain == BUILTIN:
-            return self._handle_missing_variable()
+    def check(
+        self,
+        frame,
+        domain,
+        varName=None,
+        prev_state=None,
+    ):
+        if varName is None:
+            varName = self.varName
 
-        self.domain = domain
-        current_value = self._get_current_value(frame, domain, varName)
-
-        if not self._isActive:
-            self._store(current_value)
-            self._isActive = True
-            return INIT_EVENT
-
-        result = oscilo_engine.check_variable(
-            frame,
-            self._lastRef,
-            self._lastCopy,
-            domain,
-            varName,
-        )
-
-        if result is None:
-            return self._handle_missing_variable()
-
-        if result is False:
-            return NO_CHANGE_EVENT
-
-        self._store(current_value)
-        return UPDATED_EVENT
-
-    def _check_with_frame_state(self, frame, domain, varName, prev_state):
         if domain == NOT_FOUND or domain == BUILTIN:
             if prev_state is None:
                 return NOT_FOUND_EVENT, None
@@ -172,7 +85,11 @@ class VariableTracker:
             return DELETED_EVENT, None
 
         self.domain = domain
-        current_value = self._get_current_value(frame, domain, varName)
+        current_value = self._get_current_value(
+            frame,
+            domain,
+            varName,
+        )
 
         if prev_state is None:
             return INIT_EVENT, self._make_state(current_value)
@@ -180,8 +97,8 @@ class VariableTracker:
         previous_ref = prev_state["ref"]
         previous_copy = prev_state["copy"]
 
-        # Immutable values do not have a snapshot. Their reference identity is
-        # sufficient because they cannot mutate in place.
+        # Immutable values do not have a snapshot. Reference identity is enough
+        # because they cannot mutate in place.
         if previous_copy is None:
             if current_value is previous_ref:
                 return NO_CHANGE_EVENT, prev_state
@@ -203,27 +120,3 @@ class VariableTracker:
             return NO_CHANGE_EVENT, prev_state
 
         return UPDATED_EVENT, self._make_state(current_value)
-
-    def check(
-        self,
-        frame,
-        domain,
-        varName=None,
-        prev_state=_STATE_UNSET,
-    ):
-        if varName is None:
-            varName = self.varName
-
-        if prev_state is _STATE_UNSET:
-            return self._check_with_instance_state(
-                frame,
-                domain,
-                varName,
-            )
-
-        return self._check_with_frame_state(
-            frame,
-            domain,
-            varName,
-            prev_state,
-        )

--- a/src/oscilo/VariableTracker.py
+++ b/src/oscilo/VariableTracker.py
@@ -19,6 +19,20 @@ NO_CHANGE_EVENT = "no_change"
 
 _ATOMIC_TYPES = (int, float, bool, str, bytes, type(None))
 
+_FRAME_STATE_IMMUTABLE_TYPES = (
+    int,
+    float,
+    bool,
+    complex,
+    str,
+    bytes,
+    tuple,
+    frozenset,
+    type(None),
+)
+
+_STATE_UNSET = object()
+
 class VariableTracker:
     def __init__(self, varName, domain=None, value=None, exists=False, frame=None):
         self.varName = varName
@@ -65,6 +79,19 @@ class VariableTracker:
         except Exception:
             return repr(value)
 
+    def _make_state(self, value):
+        # Frame state always keeps the current live reference. Only values whose
+        # type may mutate in place need a detached snapshot for later comparison.
+        snapshot = None
+
+        if not isinstance(value, _FRAME_STATE_IMMUTABLE_TYPES):
+            snapshot = copy.deepcopy(value)
+
+        return {
+            "ref": value,
+            "copy": snapshot,
+        }
+
     def _store(self, value):
         # Store both a live reference and a snapshot for native change detection.
         snapshot = self._make_snapshot(value)
@@ -91,9 +118,20 @@ class VariableTracker:
 
         return NOT_FOUND_EVENT
 
-    def get_snapshot(self):
-        # Return a fresh snapshot so callers cannot mutate internal tracker state.
-        return self._make_snapshot(self._lastSnapshot)
+    def get_snapshot(self, state=_STATE_UNSET):
+        # Keep the existing no-argument path until the dispatcher is migrated to
+        # frame-local state in the following stages.
+        if state is _STATE_UNSET:
+            return self._make_snapshot(self._lastSnapshot)
+
+        if state is None:
+            return None
+
+        if state["copy"] is None:
+            return state["ref"]
+
+        # Do not expose the stored mutable snapshot directly to callers.
+        return copy.deepcopy(state["copy"])
 
     def check(self, frame, domain, varName=None):
         if varName is None:

--- a/src/oscilo/VariableTracker.py
+++ b/src/oscilo/VariableTracker.py
@@ -18,15 +18,13 @@ DELETED_EVENT = "deleted"
 NOT_FOUND_EVENT = "not_found"
 NO_CHANGE_EVENT = "no_change"
 
-_FRAME_STATE_IMMUTABLE_TYPES = (
+_FRAME_STATE_ATOMIC_TYPES = (
     int,
     float,
     bool,
     complex,
     str,
     bytes,
-    tuple,
-    frozenset,
     type(None),
 )
 
@@ -37,11 +35,12 @@ class VariableTracker:
         self.domain = domain
 
     def _make_state(self, value):
-        # Frame state always keeps the current live reference. Only values whose
-        # type may mutate in place need a detached snapshot for later comparison.
+        # Frame state always keeps the current live reference. Only atomic values
+        # can be compared by identity alone. Containers need a detached snapshot
+        # because they may hold mutable objects even when the container is immutable.
         snapshot = None
 
-        if not isinstance(value, _FRAME_STATE_IMMUTABLE_TYPES):
+        if not isinstance(value, _FRAME_STATE_ATOMIC_TYPES):
             snapshot = copy.deepcopy(value)
 
         return {
@@ -97,8 +96,8 @@ class VariableTracker:
         previous_ref = prev_state["ref"]
         previous_copy = prev_state["copy"]
 
-        # Immutable values do not have a snapshot. Reference identity is enough
-        # because they cannot mutate in place.
+        # Atomic values do not have a snapshot. Reference identity is enough
+        # because they cannot contain independently mutable state.
         if previous_copy is None:
             if current_value is previous_ref:
                 return NO_CHANGE_EVENT, prev_state

--- a/src/oscilo/VariableTracker.py
+++ b/src/oscilo/VariableTracker.py
@@ -133,18 +133,17 @@ class VariableTracker:
         # Do not expose the stored mutable snapshot directly to callers.
         return copy.deepcopy(state["copy"])
 
-    def check(self, frame, domain, varName=None):
-        if varName is None:
-            varName = self.varName
-
+    def _check_with_instance_state(self, frame, domain, varName):
+        # Temporary compatibility path for the current dispatcher. This path is
+        # removed after the dispatcher migrates to frame-local state.
         if domain == NOT_FOUND or domain == BUILTIN:
             return self._handle_missing_variable()
 
         self.domain = domain
-        currentVal = self._get_current_value(frame, domain, varName)
+        current_value = self._get_current_value(frame, domain, varName)
 
         if not self._isActive:
-            self._store(currentVal)
+            self._store(current_value)
             self._isActive = True
             return INIT_EVENT
 
@@ -162,5 +161,69 @@ class VariableTracker:
         if result is False:
             return NO_CHANGE_EVENT
 
-        self._store(currentVal)
+        self._store(current_value)
         return UPDATED_EVENT
+
+    def _check_with_frame_state(self, frame, domain, varName, prev_state):
+        if domain == NOT_FOUND or domain == BUILTIN:
+            if prev_state is None:
+                return NOT_FOUND_EVENT, None
+
+            return DELETED_EVENT, None
+
+        self.domain = domain
+        current_value = self._get_current_value(frame, domain, varName)
+
+        if prev_state is None:
+            return INIT_EVENT, self._make_state(current_value)
+
+        previous_ref = prev_state["ref"]
+        previous_copy = prev_state["copy"]
+
+        # Immutable values do not have a snapshot. Their reference identity is
+        # sufficient because they cannot mutate in place.
+        if previous_copy is None:
+            if current_value is previous_ref:
+                return NO_CHANGE_EVENT, prev_state
+
+            return UPDATED_EVENT, self._make_state(current_value)
+
+        result = oscilo_engine.check_variable(
+            frame,
+            previous_ref,
+            previous_copy,
+            domain,
+            varName,
+        )
+
+        if result is None:
+            return DELETED_EVENT, None
+
+        if result is False:
+            return NO_CHANGE_EVENT, prev_state
+
+        return UPDATED_EVENT, self._make_state(current_value)
+
+    def check(
+        self,
+        frame,
+        domain,
+        varName=None,
+        prev_state=_STATE_UNSET,
+    ):
+        if varName is None:
+            varName = self.varName
+
+        if prev_state is _STATE_UNSET:
+            return self._check_with_instance_state(
+                frame,
+                domain,
+                varName,
+            )
+
+        return self._check_with_frame_state(
+            frame,
+            domain,
+            varName,
+            prev_state,
+        )

--- a/src/oscilo/_core.py
+++ b/src/oscilo/_core.py
@@ -3,7 +3,6 @@ import sys
 
 from .FileWriter import FileWriter
 from .HistoryBuffer import HistoryBuffer
-from .ScopeResolver import ScopeResolver
 from .TraceDispatcher import TraceDispatcher
 
 
@@ -12,7 +11,6 @@ class _Oscilo:
         self.fileName = fileName
         self.buffer = HistoryBuffer()
         self.dispatcher = TraceDispatcher(self.buffer)
-        self.resolver = ScopeResolver()
         self.fileWriter = FileWriter()
         self._saved = False
 
@@ -20,12 +18,11 @@ class _Oscilo:
         atexit.register(self._finalSave)
 
     def register(self, varName, frame=None):
-        # Use the caller's frame by default so the requested variable can be resolved.
+        # Pass the caller's frame so the dispatcher can resolve the variable.
         if frame is None:
             frame = sys._getframe(1)
 
-        domain, value = self.resolver.resolve(frame, varName)
-        self.dispatcher.register(varName, domain, value, frame)
+        self.dispatcher.register(varName, frame=frame)
 
     def _finalSave(self):
         # Keep this method idempotent because it may be called manually and by atexit.

--- a/tests/test_call_context.py
+++ b/tests/test_call_context.py
@@ -1,0 +1,242 @@
+import unittest
+
+from oscilo.CallContext import CallContextManager
+
+
+class FakeFrame:
+    def __init__(self, name, f_back=None):
+        self.name = name
+        self.f_back = f_back
+        self.f_trace = None
+        self.f_trace_lines = True
+
+    def __repr__(self):
+        return f"FakeFrame({self.name!r})"
+
+
+class TestCallContextManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = CallContextManager()
+
+    def test_context_is_created_lazily(self):
+        frame = FakeFrame("root")
+
+        self.assertEqual(self.manager._contexts, {})
+
+        context = self.manager.ensure_context(frame)
+
+        self.assertEqual(context["call_id"], 1)
+        self.assertIsNone(context["parent_call_id"])
+        self.assertEqual(context["call_depth"], 1)
+        self.assertIs(self.manager._contexts[frame], context)
+
+    def test_first_logging_frame_becomes_context_root(self):
+        unrelated_parent = FakeFrame("unrelated")
+        frame = FakeFrame(
+            "logging-root",
+            f_back=unrelated_parent,
+        )
+
+        context = self.manager.ensure_context(frame)
+
+        self.assertEqual(context["call_depth"], 1)
+        self.assertIsNone(context["parent_call_id"])
+        self.assertNotIn(
+            unrelated_parent,
+            self.manager._contexts,
+        )
+
+    def test_existing_context_is_reused(self):
+        frame = FakeFrame("root")
+
+        first_context = self.manager.ensure_context(frame)
+        second_context = self.manager.ensure_context(frame)
+
+        self.assertIs(second_context, first_context)
+        self.assertEqual(self.manager._next_call_id, 2)
+
+    def test_direct_child_uses_existing_parent_context(self):
+        parent = FakeFrame("parent")
+        child = FakeFrame(
+            "child",
+            f_back=parent,
+        )
+
+        parent_context = self.manager.ensure_context(parent)
+        child_context = self.manager.ensure_context(child)
+
+        self.assertEqual(
+            child_context["parent_call_id"],
+            parent_context["call_id"],
+        )
+        self.assertEqual(child_context["call_depth"], 2)
+        self.assertIsNone(child.f_trace)
+
+    def test_missing_ancestor_contexts_are_created(self):
+        root = FakeFrame("root")
+        middle = FakeFrame(
+            "middle",
+            f_back=root,
+        )
+        leaf = FakeFrame(
+            "leaf",
+            f_back=middle,
+        )
+
+        root_context = self.manager.ensure_context(root)
+        leaf_context = self.manager.ensure_context(leaf)
+        middle_context = self.manager._contexts[middle]
+
+        self.assertEqual(
+            middle_context["parent_call_id"],
+            root_context["call_id"],
+        )
+        self.assertEqual(middle_context["call_depth"], 2)
+
+        self.assertEqual(
+            leaf_context["parent_call_id"],
+            middle_context["call_id"],
+        )
+        self.assertEqual(leaf_context["call_depth"], 3)
+
+        self.assertTrue(callable(middle.f_trace))
+        self.assertFalse(middle.f_trace_lines)
+        self.assertIsNone(leaf.f_trace)
+
+    def test_sibling_contexts_share_parent(self):
+        root = FakeFrame("root")
+        left = FakeFrame(
+            "left",
+            f_back=root,
+        )
+        right = FakeFrame(
+            "right",
+            f_back=root,
+        )
+
+        root_context = self.manager.ensure_context(root)
+        left_context = self.manager.ensure_context(left)
+        right_context = self.manager.ensure_context(right)
+
+        self.assertEqual(
+            left_context["parent_call_id"],
+            root_context["call_id"],
+        )
+        self.assertEqual(
+            right_context["parent_call_id"],
+            root_context["call_id"],
+        )
+        self.assertNotEqual(
+            left_context["call_id"],
+            right_context["call_id"],
+        )
+        self.assertEqual(left_context["call_depth"], 2)
+        self.assertEqual(right_context["call_depth"], 2)
+
+    def test_relevant_frame_is_removed_on_return(self):
+        frame = FakeFrame("relevant")
+
+        first_context = self.manager.ensure_context(frame)
+        self.manager.on_return(frame)
+
+        self.assertNotIn(frame, self.manager._contexts)
+
+        second_context = self.manager.ensure_context(frame)
+
+        self.assertNotEqual(
+            first_context["call_id"],
+            second_context["call_id"],
+        )
+
+    def test_cleanup_trace_removes_gap_frame_on_return(self):
+        root = FakeFrame("root")
+        middle = FakeFrame(
+            "middle",
+            f_back=root,
+        )
+        leaf = FakeFrame(
+            "leaf",
+            f_back=middle,
+        )
+
+        self.manager.ensure_context(root)
+        self.manager.ensure_context(leaf)
+
+        cleanup_trace = middle.f_trace
+        result = cleanup_trace(
+            middle,
+            "return",
+            None,
+        )
+
+        self.assertIsNone(result)
+        self.assertNotIn(middle, self.manager._contexts)
+        self.assertIsNone(middle.f_trace)
+        self.assertTrue(middle.f_trace_lines)
+
+    def test_complete_return_sequence_leaves_no_contexts(self):
+        root = FakeFrame("root")
+        middle = FakeFrame(
+            "middle",
+            f_back=root,
+        )
+        leaf = FakeFrame(
+            "leaf",
+            f_back=middle,
+        )
+
+        self.manager.ensure_context(root)
+        self.manager.ensure_context(leaf)
+
+        cleanup_trace = middle.f_trace
+
+        self.manager.on_return(leaf)
+        cleanup_trace(middle, "return", None)
+        self.manager.on_return(root)
+
+        self.assertEqual(self.manager._contexts, {})
+        self.assertEqual(self.manager._cleanup_traces, {})
+
+    def test_clear_restores_cleanup_traces_and_resets_ids(self):
+        root = FakeFrame("root")
+        middle = FakeFrame(
+            "middle",
+            f_back=root,
+        )
+        leaf = FakeFrame(
+            "leaf",
+            f_back=middle,
+        )
+
+        self.manager.ensure_context(root)
+        self.manager.ensure_context(leaf)
+
+        self.assertTrue(callable(middle.f_trace))
+        self.assertFalse(middle.f_trace_lines)
+
+        self.manager.clear()
+
+        self.assertEqual(self.manager._contexts, {})
+        self.assertEqual(self.manager._cleanup_traces, {})
+        self.assertIsNone(middle.f_trace)
+        self.assertTrue(middle.f_trace_lines)
+
+        new_root = FakeFrame("new-root")
+        new_context = self.manager.ensure_context(new_root)
+
+        self.assertEqual(new_context["call_id"], 1)
+        self.assertIsNone(new_context["parent_call_id"])
+        self.assertEqual(new_context["call_depth"], 1)
+
+    def test_none_frame_returns_none(self):
+        self.assertIsNone(
+            self.manager.ensure_context(None)
+        )
+
+        self.manager.on_return(None)
+
+        self.assertEqual(self.manager._contexts, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_oscilo_components.py
+++ b/tests/test_oscilo_components.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import Mock
 
 from oscilo._core import _Oscilo
 from oscilo.FileWriter import FileWriter
@@ -80,6 +81,18 @@ class TestVMlogComponents(unittest.TestCase):
             lines = read_jsonl(filename)
 
         self.assertEqual(lines, history)
+
+    def test_oscilo_register_delegates_resolution_to_dispatcher(self):
+        monitor = object.__new__(_Oscilo)
+        monitor.dispatcher = Mock()
+        frame = sys._getframe()
+
+        monitor.register("target", frame=frame)
+
+        monitor.dispatcher.register.assert_called_once_with(
+            "target",
+            frame=frame,
+        )
 
     def test_scope_resolver_finds_local_variable_first(self):
         resolver = ScopeResolver()

--- a/tests/test_trace_dispatcher.py
+++ b/tests/test_trace_dispatcher.py
@@ -1,0 +1,318 @@
+import sys
+import unittest
+
+from oscilo.HistoryBuffer import HistoryBuffer
+from oscilo.TraceDispatcher import TraceDispatcher
+
+MODULE_LEVEL_COUNTER = {"value": 0}
+
+
+def events_for(history, name):
+    return [(entry["event"], entry["data"]) for entry in history if entry["name"] == name]
+
+
+class TestTraceDispatcherFrameRelevance(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_irrelevant_frame_call_event_returns_none(self):
+        target = [1, 2]
+        self.dispatcher.register("target", frame=sys._getframe())
+
+        def unrelated():
+            local_only = "no tracked variable in this scope"
+            return sys._getframe()
+
+        frame = unrelated()
+        result = self.dispatcher._trace_calls(frame, "call", None)
+
+        self.assertIsNone(result)
+
+    def test_unresolved_registration_spreads_relevance_across_module_frames(self):
+        # A registration whose variable does not exist anywhere yet cannot be
+        # scoped to a single code object in advance (we don't know which
+        # frame will eventually define it), so it stays relevant to every
+        # frame sharing this module's globals until it resolves or is
+        # unregistered. This is a deliberate cost of supporting "register
+        # before the variable exists", not a cache bug: it trades away the
+        # return-None fast path for any frame in this module for the ability
+        # to catch a not-yet-existing global appearing anywhere in it.
+        varname = "test_trace_dispatcher_not_yet_defined"
+        self.assertNotIn(varname, globals())
+
+        self.dispatcher.register(varname, frame=sys._getframe())
+
+        def elsewhere_in_module():
+            return sys._getframe()
+
+        frame = elsewhere_in_module()
+        self.assertTrue(callable(self.dispatcher._trace_calls(frame, "call", None)))
+
+        def define_it():
+            globals()[varname] = "now-exists"
+            marker = "checkpoint"
+            self.assertEqual(marker, "checkpoint")
+
+        try:
+            define_it()
+
+            events = events_for(self.buffer.getHistory(), varname)
+            self.assertEqual(events, [("init", "now-exists")])
+        finally:
+            globals().pop(varname, None)
+
+    def test_late_defined_local_initializes_once_defined(self):
+        def scenario():
+            self.dispatcher.register("later_var", frame=sys._getframe())
+            later_var = "now-exists"
+            marker = "checkpoint"
+            self.assertEqual(marker, "checkpoint")
+
+        scenario()
+
+        events = events_for(self.buffer.getHistory(), "later_var")
+        self.assertEqual(events, [("init", "now-exists")])
+
+
+class TestTraceDispatcherRecursion(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_recursion_keeps_frame_state_isolated(self):
+        def recurse(n):
+            acc = n
+            self.dispatcher.register("acc", frame=sys._getframe())
+            if n > 1:
+                recurse(n - 1)
+
+        recurse(3)
+
+        events = events_for(self.buffer.getHistory(), "acc")
+        self.assertEqual(events, [("init", 3), ("init", 2), ("init", 1)])
+
+    def test_recursion_updates_are_isolated_per_frame(self):
+        def recurse(n):
+            acc = [n]
+            self.dispatcher.register("acc", frame=sys._getframe())
+            if n > 1:
+                recurse(n - 1)
+            acc.append(n * 100)
+
+        recurse(3)
+
+        events = events_for(self.buffer.getHistory(), "acc")
+        self.assertEqual(
+            events,
+            [
+                ("init", [3]),
+                ("init", [2]),
+                ("init", [1]),
+                ("updated", [1, 100]),
+                ("updated", [2, 200]),
+                ("updated", [3, 300]),
+            ],
+        )
+
+    def test_repeated_registration_in_recursion_does_not_proliferate_trackers(self):
+        def recurse(n):
+            acc = n
+            self.dispatcher.register("acc", frame=sys._getframe())
+            if n > 1:
+                recurse(n - 1)
+
+        recurse(3)
+
+        acc_trackers = [t for t in self.dispatcher._trackers if t.varName == "acc"]
+        self.assertEqual(len(acc_trackers), 1)
+
+        events = events_for(self.buffer.getHistory(), "acc")
+        self.assertEqual(events, [("init", 3), ("init", 2), ("init", 1)])
+
+    def test_sequential_calls_reuse_tracker_and_isolate_state(self):
+        def once(value):
+            local_var = value
+            self.dispatcher.register("local_var", frame=sys._getframe())
+
+        once(1)
+        once(2)
+        once(3)
+
+        local_trackers = [t for t in self.dispatcher._trackers if t.varName == "local_var"]
+        self.assertEqual(len(local_trackers), 1)
+
+        events = events_for(self.buffer.getHistory(), "local_var")
+        self.assertEqual(events, [("init", 1), ("init", 2), ("init", 3)])
+
+
+class TestTraceDispatcherConsecutiveRegistration(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_consecutive_registration_in_same_frame_preserves_both(self):
+        frame = sys._getframe()
+        first = [1]
+        second = "alpha"
+
+        self.dispatcher.register("first", frame=frame)
+        self.dispatcher.register("second", frame=frame)
+
+        self.assertEqual(len(self.dispatcher._frame_states), 1)
+
+        first.append(2)
+        second = "beta"
+        marker = "checkpoint"
+        self.assertEqual(marker, "checkpoint")
+
+        history = self.buffer.getHistory()
+        first_events = events_for(history, "first")
+        second_events = events_for(history, "second")
+
+        self.assertEqual(first_events[0], ("init", [1]))
+        self.assertEqual(first_events[-1], ("updated", [1, 2]))
+        self.assertEqual(second_events[0], ("init", "alpha"))
+        self.assertEqual(second_events[-1], ("updated", "beta"))
+
+    def test_register_stores_new_state_in_shared_frame_state(self):
+        frame = sys._getframe()
+        target = [1, 2]
+
+        self.dispatcher.register("target", frame=frame)
+
+        frame_state = self.dispatcher._frame_states[frame]
+        self.assertIn("target", frame_state)
+        self.assertIs(frame_state["target"]["ref"], target)
+
+
+class TestTraceDispatcherGlobalDedup(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_global_change_is_not_duplicated_across_active_frames(self):
+        global MODULE_LEVEL_COUNTER
+        MODULE_LEVEL_COUNTER = {"value": 0}
+
+        def recurse(depth):
+            if depth == 0:
+                MODULE_LEVEL_COUNTER["value"] += 1
+                marker = "leaf"
+                self.assertEqual(marker, "leaf")
+                return
+            recurse(depth - 1)
+            marker = "unwind"
+            self.assertEqual(marker, "unwind")
+
+        self.dispatcher.register("MODULE_LEVEL_COUNTER", frame=sys._getframe())
+        recurse(3)
+
+        events = events_for(self.buffer.getHistory(), "MODULE_LEVEL_COUNTER")
+        self.assertEqual(events, [("init", {"value": 0}), ("updated", {"value": 1})])
+
+    def test_register_stores_new_state_in_global_states(self):
+        global MODULE_LEVEL_COUNTER
+        MODULE_LEVEL_COUNTER = {"value": 0}
+
+        tracker = self.dispatcher.register("MODULE_LEVEL_COUNTER", frame=sys._getframe())
+
+        self.assertIn(tracker, self.dispatcher._global_states)
+        self.assertIs(self.dispatcher._global_states[tracker]["ref"], MODULE_LEVEL_COUNTER)
+
+
+class TestTraceDispatcherCallContextLaziness(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_context_created_lazily_only_on_buffered_event(self):
+        observed_before = []
+        observed_after = []
+
+        def scenario():
+            self.dispatcher.register("never_seen", frame=sys._getframe())
+            observed_before.append(dict(self.dispatcher._context_manager._contexts))
+
+            never_seen = "now-exists"
+            marker = "trigger check"
+            observed_after.append(dict(self.dispatcher._context_manager._contexts))
+            self.assertEqual(marker, "trigger check")
+
+        scenario()
+
+        self.assertEqual(observed_before[0], {})
+        self.assertEqual(len(observed_after[0]), 1)
+
+
+class TestTraceDispatcherCacheInvalidation(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_cache_invalidated_on_register_and_unregister(self):
+        # Assert on the effect of invalidation (does relevance reflect the
+        # latest tracker set?) rather than on the cache dict being empty:
+        # tracing is globally active here, so unrelated internal calls can
+        # repopulate _frame_cache between "clear" and "assert" regardless of
+        # whether invalidation itself worked.
+        a = 1
+        b = 2
+        frame = sys._getframe()
+        self.dispatcher.register("a", frame=frame)
+
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual({tracker.varName for tracker in local_relevant}, {"a"})
+
+        tracker_b = self.dispatcher.register("b", frame=frame)
+
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual({tracker.varName for tracker in local_relevant}, {"a", "b"})
+
+        self.dispatcher.unregister(tracker_b)
+
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual({tracker.varName for tracker in local_relevant}, {"a"})
+
+
+class TestTraceDispatcherStopCleanup(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def test_stop_clears_call_context_and_frame_state(self):
+        def recurse(n):
+            acc = n
+            self.dispatcher.register("acc", frame=sys._getframe())
+            if n > 1:
+                recurse(n - 1)
+
+        recurse(3)
+        self.dispatcher.stop()
+
+        self.assertEqual(self.dispatcher._context_manager._contexts, {})
+        self.assertEqual(self.dispatcher._context_manager._cleanup_traces, {})
+        self.assertEqual(self.dispatcher._frame_states, {})
+        self.assertEqual(self.dispatcher._trackers, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_trace_dispatcher.py
+++ b/tests/test_trace_dispatcher.py
@@ -16,6 +16,17 @@ class TestTraceDispatcherFrameRelevance(unittest.TestCase):
         self.buffer = HistoryBuffer()
         self.dispatcher = TraceDispatcher(self.buffer)
 
+    def test_register_requires_frame(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "frame is required",
+        ):
+            self.dispatcher.register("target", frame=None)
+
+        self.assertEqual(self.dispatcher._trackers, [])
+        self.assertEqual(self.dispatcher._frame_cache, {})
+        self.assertFalse(self.dispatcher._is_tracing)
+
     def tearDown(self):
         self.dispatcher.stop()
 

--- a/tests/test_tracker_selection.py
+++ b/tests/test_tracker_selection.py
@@ -1,0 +1,161 @@
+import unittest
+
+from oscilo.HistoryBuffer import HistoryBuffer
+from oscilo.TraceDispatcher import TraceDispatcher
+
+
+class FakeFrame:
+    def __init__(self, code, globals_dict, locals_dict=None, lineno=1):
+        self.f_code = code
+        self.f_globals = globals_dict
+        self.f_locals = {} if locals_dict is None else locals_dict
+        self.f_builtins = {}
+        self.f_lineno = lineno
+        self.f_trace = None
+        self.f_trace_lines = True
+        self.f_back = None
+
+
+def _code_with_locals(*names):
+    # Build a throwaway function whose code object declares exactly these
+    # local names, without needing a real call/frame for it.
+    lines = ["def _target():"]
+    for name in names:
+        lines.append(f"    {name} = None")
+    lines.append("    return None")
+
+    namespace = {}
+    exec("\n".join(lines), namespace)
+    return namespace["_target"].__code__
+
+
+class TestTrackerSelectionCache(unittest.TestCase):
+    def setUp(self):
+        self.dispatcher = TraceDispatcher(HistoryBuffer())
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_local_candidate_requires_exact_code_object(self):
+        code_a = _code_with_locals("target")
+        code_b = _code_with_locals("target")  # same name, unrelated function
+        globals_dict = {}
+
+        frame_a = FakeFrame(code_a, globals_dict)
+        tracker = self.dispatcher.register("target", frame=frame_a)
+
+        frame_b = FakeFrame(code_b, globals_dict)
+        local_relevant, global_relevant = self.dispatcher._relevant_for(frame_b)
+
+        self.assertNotIn(tracker, local_relevant)
+        self.assertNotIn(tracker, global_relevant)
+
+    def test_local_candidate_matches_same_code_object_on_another_frame(self):
+        code = _code_with_locals("target")
+        globals_dict = {}
+
+        frame_a = FakeFrame(code, globals_dict)
+        tracker = self.dispatcher.register("target", frame=frame_a)
+
+        frame_b = FakeFrame(code, globals_dict)  # e.g. a later call of the same function
+        local_relevant, _ = self.dispatcher._relevant_for(frame_b)
+
+        self.assertIn(tracker, local_relevant)
+
+    def test_global_candidate_requires_exact_globals_identity(self):
+        code = _code_with_locals()  # "counter" is not a local name here
+        module_globals = {"counter": 1}
+        other_globals = {"counter": 1}
+
+        frame_a = FakeFrame(code, module_globals)
+        tracker = self.dispatcher.register("counter", frame=frame_a)
+
+        frame_other_module = FakeFrame(code, other_globals)
+        _, global_relevant = self.dispatcher._relevant_for(frame_other_module)
+
+        self.assertNotIn(tracker, global_relevant)
+
+    def test_global_candidate_matches_shared_globals_across_functions(self):
+        code_caller = _code_with_locals()
+        code_callee = _code_with_locals()
+        module_globals = {"counter": 1}
+
+        frame_a = FakeFrame(code_caller, module_globals)
+        tracker = self.dispatcher.register("counter", frame=frame_a)
+
+        frame_b = FakeFrame(code_callee, module_globals)
+        _, global_relevant = self.dispatcher._relevant_for(frame_b)
+
+        self.assertIn(tracker, global_relevant)
+
+    def test_irrelevant_frame_call_event_returns_none(self):
+        code_a = _code_with_locals("target")
+        frame_a = FakeFrame(code_a, {})
+        self.dispatcher.register("target", frame=frame_a)
+
+        unrelated_code = _code_with_locals("nothing_tracked")
+        unrelated_frame = FakeFrame(unrelated_code, {})
+
+        result = self.dispatcher._trace_calls(unrelated_frame, "call", None)
+
+        self.assertIsNone(result)
+
+    def test_relevant_frame_call_event_returns_tracer(self):
+        code = _code_with_locals()
+        module_globals = {"counter": 1}
+
+        frame_a = FakeFrame(code, module_globals)
+        self.dispatcher.register("counter", frame=frame_a)
+
+        frame_b = FakeFrame(code, module_globals)
+        result = self.dispatcher._trace_calls(frame_b, "call", None)
+
+        self.assertTrue(callable(result))
+        self.assertIs(frame_b.f_trace, result)
+
+    def test_cache_invalidated_on_register(self):
+        # Assert on the effect of invalidation (relevance reflects the
+        # latest tracker set) rather than on _frame_cache being empty, since
+        # unrelated calls can repopulate it once tracing is globally active.
+        code = _code_with_locals("a", "b")
+        frame = FakeFrame(code, {})
+
+        self.dispatcher.register("a", frame=frame)
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual({tracker.varName for tracker in local_relevant}, {"a"})
+
+        self.dispatcher.register("b", frame=frame)
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual({tracker.varName for tracker in local_relevant}, {"a", "b"})
+
+    def test_cache_invalidated_on_unregister(self):
+        code = _code_with_locals("a")
+        frame = FakeFrame(code, {})
+
+        tracker = self.dispatcher.register("a", frame=frame)
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual(local_relevant, [tracker])
+
+        self.dispatcher.unregister(tracker)
+        local_relevant, _ = self.dispatcher._relevant_for(frame)
+        self.assertEqual(local_relevant, [])
+
+    def test_cache_splits_candidates_by_code_structure(self):
+        code = _code_with_locals("local_name")
+        globals_dict = {}
+        frame = FakeFrame(code, globals_dict)
+
+        local_tracker = self.dispatcher.register("local_name", frame=frame)
+        global_tracker = self.dispatcher.register("global_name", frame=frame)
+
+        local_candidates, global_candidates, entry_globals = self.dispatcher._get_cache_entry(frame)
+
+        self.assertIn(local_tracker, local_candidates)
+        self.assertNotIn(local_tracker, global_candidates)
+        self.assertIn(global_tracker, global_candidates)
+        self.assertNotIn(global_tracker, local_candidates)
+        self.assertIs(entry_globals, globals_dict)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_variable_tracker.py
+++ b/tests/test_variable_tracker.py
@@ -40,13 +40,20 @@ class TestVariableTrackerState(unittest.TestCase):
         self.assertIsNone(state["ref"])
         self.assertIsNone(state["copy"])
 
-    def test_immutable_container_keeps_reference_without_copy(self):
-        value = (1, 2, 3)
+    def test_tuple_with_mutable_member_uses_deepcopy(self):
+        value = ([1, 2], 3)
 
         state = self.tracker._make_state(value)
 
         self.assertIs(state["ref"], value)
-        self.assertIsNone(state["copy"])
+        self.assertEqual(state["copy"], ([1, 2], 3))
+        self.assertIsNot(state["copy"], value)
+        self.assertIsNot(state["copy"][0], value[0])
+
+        value[0].append(4)
+
+        self.assertEqual(state["ref"], ([1, 2, 4], 3))
+        self.assertEqual(state["copy"], ([1, 2], 3))
 
     def test_mutable_list_state_uses_deepcopy(self):
         value = [1, 2]
@@ -99,8 +106,8 @@ class TestVariableTrackerState(unittest.TestCase):
         self.assertIsNot(state["copy"], value)
         self.assertEqual(state["copy"].value, ["before"])
 
-    def test_get_snapshot_returns_reference_for_immutable_state(self):
-        value = (1, 2)
+    def test_get_snapshot_returns_reference_for_atomic_state(self):
+        value = "ready"
         state = self.tracker._make_state(value)
 
         snapshot = self.tracker.get_snapshot(state)
@@ -192,6 +199,31 @@ class TestVariableTrackerState(unittest.TestCase):
         self.assertIs(new_state["ref"], target)
         self.assertEqual(new_state["copy"], [1, 2])
         self.assertEqual(state["copy"], [1])
+
+    def test_frame_state_check_detects_nested_tuple_mutation(self):
+        target = ([1, 2], 3)
+        frame = sys._getframe()
+
+        _, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        target[0].append(4)
+
+        event_name, new_state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, UPDATED_EVENT)
+        self.assertIs(new_state["ref"], target)
+        self.assertEqual(new_state["copy"], ([1, 2, 4], 3))
+        self.assertEqual(state["copy"], ([1, 2], 3))
 
     def test_frame_state_check_detects_immutable_reassignment(self):
         target = "before"

--- a/tests/test_variable_tracker.py
+++ b/tests/test_variable_tracker.py
@@ -1,0 +1,136 @@
+import unittest
+
+from oscilo.VariableTracker import VariableTracker
+
+
+class MutableValue:
+    def __init__(self, value):
+        self.value = value
+
+
+class TestVariableTrackerState(unittest.TestCase):
+    def setUp(self):
+        self.tracker = VariableTracker("target")
+
+    def test_atomic_value_state_keeps_reference_without_copy(self):
+        value = "ready"
+
+        state = self.tracker._make_state(value)
+
+        self.assertIs(state["ref"], value)
+        self.assertIsNone(state["copy"])
+
+    def test_none_state_keeps_reference_without_copy(self):
+        state = self.tracker._make_state(None)
+
+        self.assertIsNone(state["ref"])
+        self.assertIsNone(state["copy"])
+
+    def test_immutable_container_keeps_reference_without_copy(self):
+        value = (1, 2, 3)
+
+        state = self.tracker._make_state(value)
+
+        self.assertIs(state["ref"], value)
+        self.assertIsNone(state["copy"])
+
+    def test_mutable_list_state_uses_deepcopy(self):
+        value = [1, 2]
+
+        state = self.tracker._make_state(value)
+
+        self.assertIs(state["ref"], value)
+        self.assertEqual(state["copy"], [1, 2])
+        self.assertIsNot(state["copy"], value)
+
+        value.append(3)
+
+        self.assertEqual(state["ref"], [1, 2, 3])
+        self.assertEqual(state["copy"], [1, 2])
+
+    def test_nested_mutable_value_uses_deepcopy(self):
+        value = {
+            "users": [
+                {
+                    "name": "Alice",
+                    "scores": [10],
+                }
+            ]
+        }
+
+        state = self.tracker._make_state(value)
+
+        value["users"][0]["scores"].append(20)
+
+        self.assertEqual(
+            state["copy"],
+            {
+                "users": [
+                    {
+                        "name": "Alice",
+                        "scores": [10],
+                    }
+                ]
+            },
+        )
+
+    def test_custom_mutable_object_uses_deepcopy(self):
+        value = MutableValue(["before"])
+
+        state = self.tracker._make_state(value)
+
+        value.value.append("after")
+
+        self.assertIs(state["ref"], value)
+        self.assertIsNot(state["copy"], value)
+        self.assertEqual(state["copy"].value, ["before"])
+
+    def test_get_snapshot_returns_reference_for_immutable_state(self):
+        value = (1, 2)
+        state = self.tracker._make_state(value)
+
+        snapshot = self.tracker.get_snapshot(state)
+
+        self.assertIs(snapshot, value)
+
+    def test_get_snapshot_returns_independent_mutable_copy(self):
+        state = self.tracker._make_state(
+            {
+                "numbers": [1, 2],
+            }
+        )
+
+        snapshot = self.tracker.get_snapshot(state)
+        snapshot["numbers"].append(3)
+
+        self.assertEqual(
+            state["copy"],
+            {
+                "numbers": [1, 2],
+            },
+        )
+        self.assertEqual(
+            self.tracker.get_snapshot(state),
+            {
+                "numbers": [1, 2],
+            },
+        )
+
+    def test_get_snapshot_returns_none_without_state(self):
+        self.assertIsNone(self.tracker.get_snapshot(None))
+
+    def test_get_snapshot_keeps_legacy_no_argument_behavior(self):
+        tracker = VariableTracker(
+            "target",
+            value=[1, 2],
+            exists=True,
+        )
+
+        snapshot = tracker.get_snapshot()
+        snapshot.append(3)
+
+        self.assertEqual(tracker.get_snapshot(), [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_variable_tracker.py
+++ b/tests/test_variable_tracker.py
@@ -1,7 +1,21 @@
+import sys
 import unittest
 
-from oscilo.VariableTracker import VariableTracker
+from oscilo.VariableTracker import (
+    DELETED_EVENT,
+    ENCLOSING,
+    GLOBAL,
+    INIT_EVENT,
+    LOCAL,
+    NO_CHANGE_EVENT,
+    NOT_FOUND,
+    NOT_FOUND_EVENT,
+    UPDATED_EVENT,
+    VariableTracker,
+)
 
+
+FRAME_STATE_GLOBAL_VALUE = ["before"]
 
 class MutableValue:
     def __init__(self, value):
@@ -130,6 +144,202 @@ class TestVariableTrackerState(unittest.TestCase):
         snapshot.append(3)
 
         self.assertEqual(tracker.get_snapshot(), [1, 2])
+
+    def test_frame_state_check_initializes_local_value(self):
+        target = [1, 2]
+        frame = sys._getframe()
+
+        event_name, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        self.assertEqual(event_name, INIT_EVENT)
+        self.assertIs(state["ref"], target)
+        self.assertEqual(state["copy"], [1, 2])
+
+    def test_frame_state_check_returns_same_state_without_change(self):
+        target = (1, 2)
+        frame = sys._getframe()
+
+        _, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+        event_name, new_state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, NO_CHANGE_EVENT)
+        self.assertIs(new_state, state)
+
+    def test_frame_state_check_detects_mutable_value_change(self):
+        target = [1]
+        frame = sys._getframe()
+
+        _, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        target.append(2)
+
+        event_name, new_state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, UPDATED_EVENT)
+        self.assertIs(new_state["ref"], target)
+        self.assertEqual(new_state["copy"], [1, 2])
+        self.assertEqual(state["copy"], [1])
+
+    def test_frame_state_check_detects_immutable_reassignment(self):
+        target = "before"
+        frame = sys._getframe()
+
+        _, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        target = "".join(["af", "ter"])
+
+        event_name, new_state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, UPDATED_EVENT)
+        self.assertEqual(new_state["ref"], "after")
+        self.assertIsNone(new_state["copy"])
+
+    def test_frame_state_check_returns_deleted_for_previous_state(self):
+        target = [1]
+        frame = sys._getframe()
+
+        _, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        del target
+
+        event_name, new_state = self.tracker.check(
+            frame,
+            NOT_FOUND,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, DELETED_EVENT)
+        self.assertIsNone(new_state)
+
+    def test_frame_state_check_returns_not_found_without_previous_state(self):
+        frame = sys._getframe()
+
+        event_name, new_state = self.tracker.check(
+            frame,
+            NOT_FOUND,
+            "missing_target",
+            None,
+        )
+
+        self.assertEqual(event_name, NOT_FOUND_EVENT)
+        self.assertIsNone(new_state)
+
+    def test_frame_state_check_does_not_mutate_instance_value_state(self):
+        target = [1]
+        frame = sys._getframe()
+
+        self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        self.assertIsNone(self.tracker._lastRef)
+        self.assertIsNone(self.tracker._lastCopy)
+        self.assertIsNone(self.tracker._lastSnapshot)
+        self.assertFalse(self.tracker._isActive)
+
+    def test_frame_state_check_tracks_global_with_external_state(self):
+        global FRAME_STATE_GLOBAL_VALUE
+
+        original_value = FRAME_STATE_GLOBAL_VALUE
+
+        try:
+            FRAME_STATE_GLOBAL_VALUE = ["before"]
+            frame = sys._getframe()
+
+            event_name, state = self.tracker.check(
+                frame,
+                GLOBAL,
+                "FRAME_STATE_GLOBAL_VALUE",
+                None,
+            )
+
+            self.assertEqual(event_name, INIT_EVENT)
+            self.assertEqual(state["copy"], ["before"])
+
+            FRAME_STATE_GLOBAL_VALUE.append("after")
+
+            event_name, new_state = self.tracker.check(
+                frame,
+                GLOBAL,
+                "FRAME_STATE_GLOBAL_VALUE",
+                state,
+            )
+
+            self.assertEqual(event_name, UPDATED_EVENT)
+            self.assertEqual(new_state["copy"], ["before", "after"])
+            self.assertIsNone(self.tracker._lastRef)
+            self.assertIsNone(self.tracker._lastCopy)
+        finally:
+            FRAME_STATE_GLOBAL_VALUE = original_value
+
+    def test_frame_state_check_tracks_enclosing_value(self):
+        target = ["before"]
+
+        def check_target(prev_state):
+            # Referencing target makes it a free variable in this frame.
+            target
+            return self.tracker.check(
+                sys._getframe(),
+                ENCLOSING,
+                "target",
+                prev_state,
+            )
+
+        event_name, state = check_target(None)
+
+        self.assertEqual(event_name, INIT_EVENT)
+        self.assertEqual(state["copy"], ["before"])
+
+        target.append("after")
+
+        event_name, new_state = check_target(state)
+
+        self.assertEqual(event_name, UPDATED_EVENT)
+        self.assertEqual(new_state["copy"], ["before", "after"])
 
 
 if __name__ == "__main__":

--- a/tests/test_variable_tracker.py
+++ b/tests/test_variable_tracker.py
@@ -133,18 +133,6 @@ class TestVariableTrackerState(unittest.TestCase):
     def test_get_snapshot_returns_none_without_state(self):
         self.assertIsNone(self.tracker.get_snapshot(None))
 
-    def test_get_snapshot_keeps_legacy_no_argument_behavior(self):
-        tracker = VariableTracker(
-            "target",
-            value=[1, 2],
-            exists=True,
-        )
-
-        snapshot = tracker.get_snapshot()
-        snapshot.append(3)
-
-        self.assertEqual(tracker.get_snapshot(), [1, 2])
-
     def test_frame_state_check_initializes_local_value(self):
         target = [1, 2]
         frame = sys._getframe()
@@ -265,21 +253,14 @@ class TestVariableTrackerState(unittest.TestCase):
         self.assertEqual(event_name, NOT_FOUND_EVENT)
         self.assertIsNone(new_state)
 
-    def test_frame_state_check_does_not_mutate_instance_value_state(self):
-        target = [1]
-        frame = sys._getframe()
-
-        self.tracker.check(
-            frame,
-            LOCAL,
-            "target",
-            None,
+    def test_tracker_instance_keeps_only_identity_metadata(self):
+        self.assertEqual(
+            vars(self.tracker),
+            {
+                "varName": "target",
+                "domain": None,
+            },
         )
-
-        self.assertIsNone(self.tracker._lastRef)
-        self.assertIsNone(self.tracker._lastCopy)
-        self.assertIsNone(self.tracker._lastSnapshot)
-        self.assertFalse(self.tracker._isActive)
 
     def test_frame_state_check_tracks_global_with_external_state(self):
         global FRAME_STATE_GLOBAL_VALUE
@@ -311,8 +292,6 @@ class TestVariableTrackerState(unittest.TestCase):
 
             self.assertEqual(event_name, UPDATED_EVENT)
             self.assertEqual(new_state["copy"], ["before", "after"])
-            self.assertIsNone(self.tracker._lastRef)
-            self.assertIsNone(self.tracker._lastCopy)
         finally:
             FRAME_STATE_GLOBAL_VALUE = original_value
 
@@ -340,6 +319,90 @@ class TestVariableTrackerState(unittest.TestCase):
 
         self.assertEqual(event_name, UPDATED_EVENT)
         self.assertEqual(new_state["copy"], ["before", "after"])
+
+    def test_deleted_variable_can_initialize_again(self):
+        target = ["first"]
+        frame = sys._getframe()
+
+        event_name, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            None,
+        )
+
+        self.assertEqual(event_name, INIT_EVENT)
+        self.assertEqual(state["copy"], ["first"])
+
+        del target
+
+        event_name, state = self.tracker.check(
+            frame,
+            NOT_FOUND,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, DELETED_EVENT)
+        self.assertIsNone(state)
+
+        target = ["second"]
+
+        event_name, state = self.tracker.check(
+            frame,
+            LOCAL,
+            "target",
+            state,
+        )
+
+        self.assertEqual(event_name, INIT_EVENT)
+        self.assertEqual(state["copy"], ["second"])
+
+    def test_recursive_frames_keep_independent_states(self):
+        tracker = VariableTracker("n")
+        observations = []
+
+        def visit(n):
+            frame = sys._getframe()
+
+            event_name, state = tracker.check(
+                frame,
+                LOCAL,
+                "n",
+                None,
+            )
+
+            self.assertEqual(event_name, INIT_EVENT)
+            self.assertEqual(state["ref"], n)
+
+            if n > 1:
+                visit(n - 1)
+
+            event_name, restored_state = tracker.check(
+                frame,
+                LOCAL,
+                "n",
+                state,
+            )
+
+            observations.append(
+                (
+                    n,
+                    event_name,
+                    restored_state["ref"],
+                )
+            )
+
+        visit(3)
+
+        self.assertEqual(
+            observations,
+            [
+                (1, NO_CHANGE_EVENT, 1),
+                (2, NO_CHANGE_EVENT, 2),
+                (3, NO_CHANGE_EVENT, 3),
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- 트래커의 **정체성**(어떤 변수를 어떻게 비교할지)과 **값 상태**(직전 ref/copy)를 분리하는 Issue #28 리팩토링 전체를 통합합니다. `VariableTracker`는 값 상태 없는 순수 정체성 객체가 되고, 직전 값은 프레임별 상태(LOCAL/ENCLOSING) 또는 트래커당 단일 타임라인(GLOBAL)으로 외부화됩니다.
- `TraceDispatcher`는 코드 객체 기반 relevance 선별을 도입해, 추적 변수와 무관한 프레임을 `call` 이벤트에서 제외합니다. 무관 함수의 라인당 오버헤드(실측 트래커 1개 기준 ~37배, 트래커 수에 선형)가 사실상 제거됩니다 (30k 라인 실측: 3.2ms vs 비추적 2.2ms).
- call context(#37)는 별도 모듈 `CallContext.py`의 `CallContextManager`로 분리되고, 실제 로그 이벤트가 발생할 때만 lazy 생성됩니다 (eager 대비 per-call 비용 3.8배 절감 실측, 무관 조상 프레임 컨텍스트 누수 0).
- 이 리팩토링으로 재귀 내 `register()` 호출의 트래커 증식, 죽은 프레임 참조 영구 잔존(메모리 누수), 단일 등록으로 함수의 모든 호출을 추적할 수 없던 프레임 고정 구조의 한계가 함께 해소됩니다.

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] **`VariableTracker` 상태 분리** (`4acfaf8`, `2078367`, `a994b3b`): `_lastRef`/`_lastCopy`/`_lastSnapshot`/`_isActive`/`frame` 제거. `check()`는 `(frame, domain, varName, prev_state) → (event_name, new_state)` 계약으로 변경, 상태 구조는 `{"ref": 참조, "copy": 가변 객체면 deepcopy 아니면 None}`. `get_snapshot(state)`는 외부 상태를 받아 스냅샷 반환 (None 입력 → None).
- [x] **`CallContextManager` 신설** (`a8f4eab`, 신규 `CallContext.py`): 첫 버퍼 이벤트 시점 lazy 컨텍스트 생성, `f_back` 체인 조상 컨텍스트 보충으로 `call_id`/`parent_call_id`/`call_depth` 링크 유지, lazy로 생성된 무관 조상에만 return 전용 정리 트레이서(`f_trace_lines=False`) 부착, `on_return`/`clear` 정리 API.
- [x] **relevance 2단 판별 + `_frame_cache`** (`3633f9c`): 코드 객체 단위 후보 분류를 캐싱하고 프레임 단위로 등록 시점 `f_code`/`f_globals` 동일성 필터 적용. relevant가 없는 프레임은 `_trace_calls`가 `None`을 반환해 line 이벤트 자체를 차단. 캐시는 등록/해제/stop 시 무효화.
- [x] **프레임별 상태 격리**: `call`마다 새 `frame_state`를 캡처한 클로저 트레이서를 생성 (클로저 캐싱·단일 활성 포인터 없음). 재귀에서 안쪽 프레임이 바깥 상태를 오염시키지 않으며, `return` 이벤트에서 마지막 변경 검사 후 상태를 폐기.
- [x] **GLOBAL 단일 타임라인**: 전역의 직전 값은 트래커당 하나(`_global_states`)로 보관해, 활성 프레임 여러 개가 같은 변경을 중복 `updated`로 기록하지 않음.
- [x] **register 멱등화 + init 경로 통합**: `(varName, f_code)` / `(varName, f_globals 정체성)` 키로 중복 등록 시 기존 트래커 재사용 (재귀 register 증식 해결). 초기 관측은 일반 line 이벤트와 동일한 검사·기록 경로를 사용해 같은 프레임 재등록 시 init 중복을 구조적으로 차단.
- [x] **테스트 54개 신규 추가** (총 99개): 트래커 단위(20) · 컨텍스트 수명(11) · relevance 선별(9) · 디스패처 동작(14). 재귀 격리, 트래커 비증식, 전역 중복 방지, stop 후 잔존 0, 미해결 등록의 모듈 전파(의도된 트레이드오프 명문화) 등 커버.
- 동작 참고: ① call_id가 실제 로깅 체인에만 부여되어 번호가 조밀해집니다 (기존 테스트는 고유성·부모 링크만 검증하므로 호환). ② `register(frame=None)` 트래커는 정체성 메타데이터가 없어 추적되지 않습니다 (실사용 경로는 항상 frame 전달). ③ 제너레이터/코루틴의 상태 수명은 기존과 동일한 실행 슬라이스 의미론으로 유지되며 #35에서 결론냅니다.

## Issue Link
<!-- Link any related issues below. e.g., Closes #12 -->
- Closes #28

## Screenshots / Videos (Optional)
<!-- Attach any visual evidence, mockups, or demos if there are UI/UX changes. -->
- N/A (UI 변경 없음)

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.