### PR TITLE
Feature/variable identity

### DIFF
--- a/src/oscilo/CallContext.py
+++ b/src/oscilo/CallContext.py
@@ -4,6 +4,13 @@ class CallContextManager:
         self._contexts = {}
         self._cleanup_traces = {}
 
+    def next_id(self):
+        # ID 공간을 공유해서, 합성된 identity(예: closure cell에 대한 ENCLOSING
+        # var_id)가 frame 기반 call_id 값과 절대 충돌하지 않도록 한다.
+        new_id = self._next_call_id
+        self._next_call_id += 1
+        return new_id
+
     def ensure_context(self, frame):
         if frame is None:
             return None
@@ -15,9 +22,9 @@ class CallContextManager:
         missing_frames = []
         current_frame = frame
 
-        # Walk toward an already known logging ancestor. Frames between that
-        # ancestor and the requested frame must also receive contexts so parent
-        # links and call depth remain continuous.
+        # 이미 알려진 logging ancestor를 향해 거슬러 올라간다. 그 ancestor와
+        # 요청된 frame 사이에 있는 frame들도 context를 가져야 parent 연결과
+        # call depth가 끊기지 않고 이어진다.
         while (
             current_frame is not None
             and current_frame not in self._contexts
@@ -26,9 +33,9 @@ class CallContextManager:
             current_frame = current_frame.f_back
 
         if current_frame is None:
-            # No logging ancestor exists. The requested frame becomes the root of
-            # a new logging chain rather than pulling unrelated interpreter and
-            # test-runner frames into the context tree.
+            # logging ancestor가 존재하지 않는다. context 트리에 무관한 인터프리터나
+            # 테스트 러너 frame을 끌어들이는 대신, 요청된 frame이 새로운 logging
+            # chain의 root가 된다.
             return self._create_context(
                 frame,
                 parent_context=None,
@@ -42,9 +49,9 @@ class CallContextManager:
                 parent_context,
             )
 
-            # The requested frame is relevant and its normal return tracer will
-            # call on_return(). Only automatically created gap frames need the
-            # lightweight return-only cleanup tracer.
+            # 요청된 frame은 관련(relevant) frame이므로 그 정상 return tracer가
+            # on_return()을 호출한다. 자동으로 생성된 gap frame만 가벼운
+            # return 전용 cleanup tracer가 필요하다.
             if missing_frame is not frame:
                 self._attach_return_cleanup(missing_frame)
 
@@ -89,8 +96,8 @@ class CallContextManager:
         if frame in self._cleanup_traces:
             return
 
-        # A frame with an existing local tracer is expected to be relevant. Its
-        # normal return path must call on_return(), so do not replace that tracer.
+        # 이미 local tracer가 있는 frame은 relevant한 frame으로 간주된다. 그
+        # 정상 return 경로가 on_return()을 호출해야 하므로 그 tracer를 대체하지 않는다.
         previous_trace = getattr(frame, "f_trace", None)
         if previous_trace is not None:
             return

--- a/src/oscilo/HistoryBuffer.py
+++ b/src/oscilo/HistoryBuffer.py
@@ -11,10 +11,11 @@ class HistoryBuffer:
     def __init__(self):
         self._history = []
 
-    def append(self, name, data, event, domain=None, line=None, func=None, call_id=None, parent_call_id=None, call_depth=None,):
+    def append(self, name, var_id, data, event, domain=None, line=None, func=None, call_id=None, parent_call_id=None, call_depth=None,):
         # Store a readable domain label so JSONL output is easy to inspect.
         history_entry = {
             "name": name,
+            "var_id": var_id,
             "data": data,
             "event": event,
             "domain": self._get_domain_label(domain),

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -364,12 +364,20 @@ class TraceDispatcher:
         return context["call_depth"]
 
     def _get_logged_domain(self, tracker, event_name, resolved_domain):
-        # 삭제로 인해 변수를 더 이상 해석할 수 없게 됐을 때는 이전 scope를 유지한다.
+        # Preserve the previous scope when deletion makes the variable unresolvable.
+        domain = resolved_domain
         if event_name == DELETED_EVENT and resolved_domain not in TRACKABLE_DOMAINS:
-            return tracker.domain
+            domain = tracker.domain
 
-        return resolved_domain
+        # ENCLOSING is only an internal LEGB classification used to route
+        # cell-based state/var_id resolution; the variable still lives in
+        # (and is owned by) a LOCAL frame from the log's point of view, so
+        # it is always reported as LOCAL, never ENCLOSING.
+        if domain == ENCLOSING:
+            return LOCAL
 
+        return domain
+    
     def _log_event(self, frame, tracker, event_name, new_state, domain, cell=None):
         context = self._context_manager.ensure_context(frame)
         call_id = self._get_context_call_id(context)

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -12,44 +12,142 @@ TRACKABLE_DOMAINS = (LOCAL, GLOBAL, ENCLOSING)
 BUFFERED_EVENTS = ("init", "updated", "deleted")
 DELETED_EVENT = "deleted"
 
+# "이 frame에 대해 cell 해석을 아직 시도하지 않음"과 "시도했지만 휴리스틱이
+# cell을 찾지 못함"(진짜 None)을 구분하기 위한 sentinel.
+_UNRESOLVED = object()
+
 class TraceDispatcher:
+    class _ClosureResolver:
+        """free variable을 뒷받침하는 실제 closure `cell` 객체를 해석한다.
+
+        `sys.settrace`의 콜백은 항상 frame 객체만 넘겨주며, 맨 frame만으로는
+        어떤 공식 Python/C API로도 closure cell을 노출시킬 방법이 없다
+        (실측 확인: `frame.f_locals`, `gc.get_referents(frame)`, 그리고 안정
+        C-API인 `PyFrame_GetVar`조차 전부 *역참조된 값*만 반환하고 cell 자체는
+        반환하지 않는다). cell은 오직 function 객체의 `__closure__`를 통해서만
+        접근 가능하므로, 이 resolver는 직접 호출자(caller)의 frame
+        (`frame.f_back`)에서 다음 조건을 만족하는 콜러블을 찾는다: (a) 추적 중인
+        frame과 같은 code 객체를 쓰고, (b) 해당 인덱스의 closure cell이 현재
+        추적 중인 frame의 실제 값과 일치한다.
+
+        이것은 보장이 아니라 휴리스틱이다. 호출 시점에 caller의 locals/globals
+        안에서 평범한 이름으로 접근 가능하지 않았던 콜러블(예: `outer()()`처럼
+        이름에 바인딩되지 않은 즉시 호출, 또는 속성/딕셔너리 접근을 통해 호출된
+        콜백)은 cell을 해석하지 못한다. `resolve`를 호출하는 쪽은 `None`을
+        "소유권을 판단할 수 없음"으로 취급하고 그에 맞게 fallback해야 한다.
+        """
+
+        def resolve(self, frame, var_name):
+            code = frame.f_code
+
+            if var_name not in code.co_freevars:
+                return None
+
+            index = code.co_freevars.index(var_name)
+            caller = frame.f_back
+
+            if caller is None:
+                return None
+
+            current_value = frame.f_locals.get(var_name)
+            candidates = list(caller.f_locals.values()) + list(caller.f_globals.values())
+
+            for candidate in candidates:
+                cell = self._match_candidate(candidate, code, index, current_value)
+                if cell is not None:
+                    return cell
+
+            return None
+
+        def _match_candidate(self, candidate, code, index, current_value):
+            # `self.method` 형태의 콜백도 처리할 수 있도록 bound method를 풀어낸다.
+            func = getattr(candidate, "__func__", candidate)
+
+            if getattr(func, "__code__", None) is not code:
+                return None
+
+            closure = getattr(func, "__closure__", None)
+            if not closure or len(closure) <= index:
+                return None
+
+            cell = closure[index]
+
+            # 같은 code 객체를 공유하는 서로 다른 여러 closure가 caller의
+            # namespace에 함께 존재할 수 있다(예: 서로 다른 이름으로 저장된
+            # 두 개의 별도 `outer()` 결과). cell이 현재 추적 중인 frame이
+            # 실행 중인 바로 그 객체를 담고 있는지 확인해서 구분한다.
+            try:
+                cell_value = cell.cell_contents
+            except ValueError:
+                # cell이 아직 바인딩되지 않음(드문 타이밍 엣지 케이스); 일치 여부를 확인할 수 없다.
+                return None
+
+            if cell_value is not current_value:
+                return None
+
+            return cell
+
     def __init__(self, buffer=None):
         self._trackers = []
         self._is_tracing = False
         self._bufferRef = buffer
         self._resolver = ScopeResolver()
         self._context_manager = CallContextManager()
+        self._closure_resolver = self._ClosureResolver()
 
-        # Cache of "which trackers matter for this code object", keyed by
-        # frame.f_code so unrelated frames can skip line tracing entirely.
+        # "이 code 객체에 어떤 tracker가 관련 있는지"를 frame.f_code로 키를
+        # 잡아 캐싱해서, 무관한 frame은 line tracing을 아예 건너뛸 수 있게 한다.
         self._frame_cache = {}
 
-        # Registration-time scope identity for each tracker, kept on the
-        # dispatcher (never on the tracker or as a live frame reference) so a
-        # tracker only ever applies to the exact function or module it was
-        # registered against.
+        # 각 tracker의 등록 시점 scope identity를 tracker나 살아있는 frame
+        # 참조가 아니라 dispatcher 쪽에 보관해서, tracker가 등록될 때의 정확한
+        # function/module에만 적용되도록 한다.
         self._tracker_codes = {}
         self._tracker_globals = {}
 
-        # Dedup keys so registering the same variable/scope twice (e.g. once
-        # per recursive call) reuses the existing tracker instead of
-        # proliferating one per call.
+        # 같은 변수/scope를 두 번(예: 재귀 호출마다) 등록해도 기존 tracker를
+        # 재사용하고 호출마다 새로 늘어나지 않도록 하는 중복 제거 키.
         self._registered_local = {}
         self._registered_global = {}
 
-        # GLOBAL variables have a single timeline shared by every frame that
-        # observes them, so their previous state lives here instead of in any
-        # one frame's state.
+        # GLOBAL 변수는 그것을 관찰하는 모든 frame이 공유하는 단일 timeline을
+        # 가지므로, 이전 상태는 어느 한 frame의 state가 아니라 여기에 산다.
         self._global_states = {}
 
-        # GLOBAL variables retain the ID of the frame where they were first
-        # registered, even when later changes occur in another call frame.
+        # GLOBAL 변수는 이후 다른 call frame에서 변경이 일어나도, 처음
+        # 등록됐던 frame의 ID를 계속 유지한다.
         self._global_var_ids = {}
 
-        # Per-active-frame local/enclosing state, keyed by the frame object
-        # itself. Entries are removed on that frame's return event and the
-        # dict is cleared on stop(), so nothing here outlives the frame.
+        # frame 객체 자체를 key로 하는, 활성 frame별 local/enclosing state.
+        # 해당 frame의 return 이벤트에서 항목이 제거되고 stop()에서 dict
+        # 전체가 비워지므로, 여기 있는 어떤 것도 frame보다 오래 살아남지 않는다.
         self._frame_states = {}
+
+        # ENCLOSING(nonlocal/freevar) 변수는 어느 한 call frame이 아니라
+        # closure cell이 소유하므로, 그 identity와 값 이력은 소유 frame의
+        # return 이후에도 살아남아야 한다(closure는 자신을 만든 함수가
+        # 반환된 지 한참 후에도 호출될 수 있다). `cell` 객체는 해시 불가능
+        # 하므로 아래 세 dict는 모두 id(cell)을 key로 쓴다; _enclosing_cell_refs는
+        # 각 cell에 대한 strong reference를 붙잡아 둬서, 추적이 활성화된 동안
+        # 그 id가 다른 무관한 객체에 재사용되지 않게 한다. GLOBAL 저장소와
+        # 마찬가지로 stop()에서 비워진다.
+        self._enclosing_var_ids = {}
+        self._enclosing_states = {}
+        self._enclosing_cell_refs = {}
+
+        # "이 frame에서 이 ENCLOSING 변수를 뒷받침하는 cell이 무엇인지"를
+        # frame으로 키를 잡아 캐싱해서, _ClosureResolver의 caller-frame
+        # 휴리스틱이 추적된 line마다가 아니라 호출마다 한 번만 실행되게 한다.
+        # 해당 frame의 return 이벤트에서 항목이 제거되고 stop()에서 비워진다.
+        # 해석 결과가 None인 경우도 캐싱해서(휴리스틱이 정말로 이 frame에 대한
+        # cell을 찾지 못한 경우), "아직 시도 안 함"과 "시도했지만 찾지 못함"을
+        # sentinel로 구분한다.
+        self._frame_cell_cache = {}
+
+        # 특정 ENCLOSING tracker에 대해 지금까지 해석된 모든 cell을 기록해서,
+        # unregister()가 _enclosing_var_ids / _enclosing_states에 새어나가게
+        # 두지 않고 그 tracker가 소유한 상태만 정확히 정리할 수 있게 한다.
+        self._tracker_cells = {}
 
     def setBuffer(self, buffer):
         self._bufferRef = buffer
@@ -60,6 +158,65 @@ class TraceDispatcher:
             varName in code.co_varnames
             or varName in code.co_cellvars
             or varName in code.co_freevars
+        )
+
+    def _is_enclosing_case(self, domain, tracker):
+        if domain == ENCLOSING:
+            return True
+
+        # 삭제됐거나 더 이상 해석 불가능한 nonlocal이라도 frame_state가 아니라
+        # cell-keyed 저장소에서 정리돼야 한다. 그렇지 않으면 DELETED_EVENT가
+        # 엉뚱한 저장소를 조회해서 아예 발생하지 않게 된다.
+        return domain not in TRACKABLE_DOMAINS and tracker.domain == ENCLOSING
+
+    def _resolve_cell_key_cached(self, frame, varName):
+        cached = self._frame_cell_cache.get(frame, _UNRESOLVED)
+        if cached is not _UNRESOLVED:
+            return cached
+
+        cell = self._closure_resolver.resolve(frame, varName)
+        cell_key = None
+
+        if cell is not None:
+            cell_key = id(cell)
+            # id로 참조하는 동안에는 cell을 계속 살려둬야 한다. 그러지 않으면
+            # 나중에 무관한 객체가 같은 주소에 할당될 수 있다.
+            self._enclosing_cell_refs[cell_key] = cell
+
+        self._frame_cell_cache[frame] = cell_key
+        return cell_key
+
+    def _get_enclosing_var_id(self, cell_key):
+        var_id = self._enclosing_var_ids.get(cell_key)
+        if var_id is None:
+            var_id = self._context_manager.next_id()
+            self._enclosing_var_ids[cell_key] = var_id
+
+        return var_id
+
+    def _record_tracker_cell(self, tracker, cell_key):
+        if cell_key is None:
+            return
+
+        self._tracker_cells.setdefault(tracker, set()).add(cell_key)
+
+    def _check_and_log_enclosing(self, frame, tracker, varName):
+        cell_key = self._resolve_cell_key_cached(frame, varName)
+        self._record_tracker_cell(tracker, cell_key)
+
+        # cell을 해석하지 못한 경우(caller-frame 휴리스틱이 소유 closure를
+        # 찾지 못함)는 기존과 동일하게 frame별 state로 fallback한다: 변수는
+        # 여전히 추적되지만 호출 간에 안정적인 identity를 갖지 못하고, var_id는
+        # 현재 call_id로 강등된다(_log_event에서 처리).
+        storage_key = cell_key if cell_key is not None else frame
+
+        return self._check_and_log(
+            frame,
+            tracker,
+            self._enclosing_states,
+            storage_key,
+            ENCLOSING,
+            cell=cell_key,
         )
 
     def register(self, varName, frame):
@@ -90,19 +247,21 @@ class TraceDispatcher:
                 context = self._context_manager.ensure_context(frame)
                 self._global_var_ids[tracker] = self._get_context_call_id(context)
 
-            # A new tracker can change which trackers apply to any code
-            # object, so the relevance cache can no longer be trusted.
+            # 새 tracker가 추가되면 어떤 code 객체에 어떤 tracker가 적용되는지가
+            # 바뀔 수 있으므로, relevance 캐시를 더 이상 신뢰할 수 없다.
             self._frame_cache.clear()
 
-        # Start global tracing once the first tracker is registered.
+        # 첫 tracker가 등록되는 시점에 전역 tracing을 시작한다.
         self._start_tracing()
 
-        # The registration frame's "call" event already happened before this
-        # tracker existed, so line tracing must be attached here explicitly
-        # (or reused if already attached by an earlier registration/call).
+        # 등록 frame의 "call" 이벤트는 이 tracker가 생기기 전에 이미 발생했으므로,
+        # line tracing을 여기서 명시적으로 붙여야 한다(또는 이전 등록/호출에서
+        # 이미 붙어 있다면 그것을 재사용한다).
         frame_state = self._ensure_frame_tracking(frame)
 
-        if is_local:
+        if self._is_enclosing_case(resolved_domain, tracker):
+            self._check_and_log_enclosing(frame, tracker, varName)
+        elif is_local:
             self._check_and_log(frame, tracker, frame_state, varName, resolved_domain)
         else:
             self._check_and_log(frame, tracker, self._global_states, tracker, resolved_domain)
@@ -123,6 +282,14 @@ class TraceDispatcher:
 
         self._global_states.pop(tracker, None)
         self._global_var_ids.pop(tracker, None)
+
+        cell_keys = self._tracker_cells.pop(tracker, None)
+        if cell_keys:
+            for cell_key in cell_keys:
+                self._enclosing_var_ids.pop(cell_key, None)
+                self._enclosing_states.pop(cell_key, None)
+                self._enclosing_cell_refs.pop(cell_key, None)
+
         self._frame_cache.clear()
 
         if not self._trackers:
@@ -153,6 +320,11 @@ class TraceDispatcher:
         self._registered_global.clear()
         self._global_states.clear()
         self._global_var_ids.clear()
+        self._enclosing_var_ids.clear()
+        self._enclosing_states.clear()
+        self._enclosing_cell_refs.clear()
+        self._frame_cell_cache.clear()
+        self._tracker_cells.clear()
         self._context_manager.clear()
 
     def _append_buffer_event(self, varName, var_id, data, event_name, domain, line, func=None, call_id=None, parent_call_id=None, call_depth=None):
@@ -192,17 +364,22 @@ class TraceDispatcher:
         return context["call_depth"]
 
     def _get_logged_domain(self, tracker, event_name, resolved_domain):
-        # Preserve the previous scope when deletion makes the variable unresolvable.
+        # 삭제로 인해 변수를 더 이상 해석할 수 없게 됐을 때는 이전 scope를 유지한다.
         if event_name == DELETED_EVENT and resolved_domain not in TRACKABLE_DOMAINS:
             return tracker.domain
 
         return resolved_domain
 
-    def _log_event(self, frame, tracker, event_name, new_state, domain):
+    def _log_event(self, frame, tracker, event_name, new_state, domain, cell=None):
         context = self._context_manager.ensure_context(frame)
         call_id = self._get_context_call_id(context)
 
-        if tracker in self._global_var_ids:
+        if domain == ENCLOSING and cell is not None:
+            # var_id는 값을 소유한 closure cell을 식별하고, call_id는 항상 이
+            # 변경이 관측된 frame을 가리킨다. 그래서 ENCLOSING 변수에 한해
+            # 이 둘은 의도적으로 서로 달라진다.
+            var_id = self._get_enclosing_var_id(cell)
+        elif tracker in self._global_var_ids:
             var_id = self._global_var_ids[tracker]
         else:
             var_id = call_id
@@ -220,7 +397,7 @@ class TraceDispatcher:
             self._get_context_call_depth(context),
         )
 
-    def _check_and_log(self, frame, tracker, storage, key, domain):
+    def _check_and_log(self, frame, tracker, storage, key, domain, cell=None):
         prev_state = storage.get(key)
         event_name, new_state = tracker.check(frame, domain, tracker.varName, prev_state)
 
@@ -230,7 +407,7 @@ class TraceDispatcher:
             storage[key] = new_state
 
         if event_name in BUFFERED_EVENTS:
-            self._log_event(frame, tracker, event_name, new_state, domain)
+            self._log_event(frame, tracker, event_name, new_state, domain, cell=cell)
 
         return event_name, new_state
 
@@ -270,7 +447,11 @@ class TraceDispatcher:
 
         for tracker in local_relevant:
             domain, _ = self._resolver.resolve(frame, tracker.varName)
-            self._check_and_log(frame, tracker, frame_state, tracker.varName, domain)
+
+            if self._is_enclosing_case(domain, tracker):
+                self._check_and_log_enclosing(frame, tracker, tracker.varName)
+            else:
+                self._check_and_log(frame, tracker, frame_state, tracker.varName, domain)
 
         for tracker in global_relevant:
             domain, _ = self._resolver.resolve(frame, tracker.varName)
@@ -286,6 +467,7 @@ class TraceDispatcher:
             if current_event == "return":
                 self._context_manager.on_return(current_frame)
                 self._frame_states.pop(current_frame, None)
+                self._frame_cell_cache.pop(current_frame, None)
                 return None
 
             return trace_lines

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -42,6 +42,10 @@ class TraceDispatcher:
         # one frame's state.
         self._global_states = {}
 
+        # GLOBAL variables retain the ID of the frame where they were first
+        # registered, even when later changes occur in another call frame.
+        self._global_var_ids = {}
+
         # Per-active-frame local/enclosing state, keyed by the frame object
         # itself. Entries are removed on that frame's return event and the
         # dict is cleared on stop(), so nothing here outlives the frame.
@@ -83,6 +87,9 @@ class TraceDispatcher:
                 self._registered_global[dedup_key] = tracker
                 self._tracker_globals[tracker] = frame.f_globals
 
+                context = self._context_manager.ensure_context(frame)
+                self._global_var_ids[tracker] = self._get_context_call_id(context)
+
             # A new tracker can change which trackers apply to any code
             # object, so the relevance cache can no longer be trusted.
             self._frame_cache.clear()
@@ -115,6 +122,7 @@ class TraceDispatcher:
             self._registered_global.pop((tracker.varName, id(globals_dict)), None)
 
         self._global_states.pop(tracker, None)
+        self._global_var_ids.pop(tracker, None)
         self._frame_cache.clear()
 
         if not self._trackers:
@@ -144,13 +152,14 @@ class TraceDispatcher:
         self._registered_local.clear()
         self._registered_global.clear()
         self._global_states.clear()
+        self._global_var_ids.clear()
         self._context_manager.clear()
 
-    def _append_buffer_event(self, varName, data, event_name, domain, line, func=None, call_id=None, parent_call_id=None, call_depth=None):
+    def _append_buffer_event(self, varName, var_id, data, event_name, domain, line, func=None, call_id=None, parent_call_id=None, call_depth=None):
         if self._bufferRef is None:
             return
 
-        self._bufferRef.append(varName, data, event_name, domain, line, func, call_id, parent_call_id, call_depth, )
+        self._bufferRef.append(varName, var_id, data, event_name, domain, line, func, call_id, parent_call_id, call_depth, )
 
     def _get_frame_line(self, frame):
         if frame is None:
@@ -190,17 +199,23 @@ class TraceDispatcher:
         return resolved_domain
 
     def _log_event(self, frame, tracker, event_name, new_state, domain):
-        # Only touch call-context bookkeeping when there is something to log.
         context = self._context_manager.ensure_context(frame)
+        call_id = self._get_context_call_id(context)
+
+        if tracker in self._global_var_ids:
+            var_id = self._global_var_ids[tracker]
+        else:
+            var_id = call_id
 
         self._append_buffer_event(
             tracker.varName,
+            var_id,
             tracker.get_snapshot(new_state),
             event_name,
             self._get_logged_domain(tracker, event_name, domain),
             self._get_frame_line(frame),
             self._get_frame_func(frame),
-            self._get_context_call_id(context),
+            call_id,
             self._get_context_parent_call_id(context),
             self._get_context_call_depth(context),
         )

--- a/tests/test_oscilo_behavior.py
+++ b/tests/test_oscilo_behavior.py
@@ -5,7 +5,7 @@ import unittest
 
 from oscilo._core import _Oscilo
 
-EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
+EXPECTED_LOG_KEYS = {"name", "var_id", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
 
@@ -213,6 +213,7 @@ class TestVMLBehavior(unittest.TestCase):
             self.assertIn(entry["domain"], TRACKING_DOMAINS)
             self.assertTrue(entry["line"] is None or isinstance(entry["line"], int))
             self.assertTrue(entry["func"] is None or isinstance(entry["func"], str))
+            self.assertIsInstance(entry["var_id"], int)
             self.assertTrue(entry["call_id"] is None or isinstance(entry["call_id"], int))
             self.assertTrue(entry["parent_call_id"] is None or isinstance(entry["parent_call_id"], int))
             self.assertTrue(entry["call_depth"] is None or isinstance(entry["call_depth"], int))
@@ -245,9 +246,13 @@ class TestVMLBehavior(unittest.TestCase):
         self.assertEqual([entry["call_depth"] for entry in init_logs], [1, 2, 3])
 
         call_ids = [entry["call_id"] for entry in init_logs]
+        var_ids = [entry["var_id"] for entry in init_logs]
         parent_call_ids = [entry["parent_call_id"] for entry in init_logs]
 
         self.assertEqual(len(set(call_ids)), 3)
+        self.assertEqual(len(set(var_ids)), 3)
+        self.assertEqual(var_ids, call_ids)
+
         self.assertIsNone(parent_call_ids[0])
         self.assertEqual(parent_call_ids[1], call_ids[0])
         self.assertEqual(parent_call_ids[2], call_ids[1])

--- a/tests/test_oscilo_components.py
+++ b/tests/test_oscilo_components.py
@@ -35,7 +35,7 @@ class TestVMlogComponents(unittest.TestCase):
         buffer = HistoryBuffer()
         original_data = {"numbers": [1, 2, 3]}
 
-        buffer.append("target", original_data, "init", LOCAL, 1)
+        buffer.append("target", 1, original_data, "init", LOCAL, 1)
 
         history = buffer.getHistory()
         history[0]["data"]["numbers"].append(4)
@@ -45,20 +45,21 @@ class TestVMlogComponents(unittest.TestCase):
         self.assertEqual(stored_history[0]["name"], "target")
         self.assertEqual(stored_history[0]["event"], "init")
         self.assertEqual(stored_history[0]["data"], {"numbers": [1, 2, 3]})
+        self.assertEqual(stored_history[0]["var_id"], 1)
 
     def test_history_buffer_clear(self):
         buffer = HistoryBuffer()
 
-        buffer.append("A", 10, "init", LOCAL, 1)
-        buffer.append("A", 20, "updated", LOCAL, 2)
+        buffer.append("A", 1, 10, "init", LOCAL, 1)
+        buffer.append("A", 1, 20, "updated", LOCAL, 2)
 
         history = buffer.getHistory()
 
         self.assertEqual(
             history,
             [
-                {"name": "A", "data": 10, "event": "init", "domain": "LOCAL", "line": 1, "func": None, "call_id": None, "parent_call_id": None, "call_depth": None,},
-                {"name": "A", "data": 20, "event": "updated", "domain": "LOCAL", "line": 2, "func": None, "call_id": None, "parent_call_id": None, "call_depth": None,},
+                {"name": "A", "var_id": 1, "data": 10, "event": "init", "domain": "LOCAL", "line": 1, "func": None, "call_id": None, "parent_call_id": None, "call_depth": None,},
+                {"name": "A", "var_id": 1, "data": 20, "event": "updated", "domain": "LOCAL", "line": 2, "func": None, "call_id": None, "parent_call_id": None, "call_depth": None,},
             ],
         )
 

--- a/tests/test_oscilo_process_lifecycle.py
+++ b/tests/test_oscilo_process_lifecycle.py
@@ -10,7 +10,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
 DEFAULT_LOG_NAME = "ocilo.jsonl"
-EXPECTED_LOG_KEYS = {"name", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
+EXPECTED_LOG_KEYS = {"name", "var_id", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
 

--- a/tests/test_trace_dispatcher.py
+++ b/tests/test_trace_dispatcher.py
@@ -231,8 +231,37 @@ class TestTraceDispatcherGlobalDedup(unittest.TestCase):
         self.dispatcher.register("MODULE_LEVEL_COUNTER", frame=sys._getframe())
         recurse(3)
 
-        events = events_for(self.buffer.getHistory(), "MODULE_LEVEL_COUNTER")
-        self.assertEqual(events, [("init", {"value": 0}), ("updated", {"value": 1})])
+        history = self.buffer.getHistory()
+        events = events_for(history, "MODULE_LEVEL_COUNTER")
+
+        self.assertEqual(
+            events,
+            [
+                ("init", {"value": 0}),
+                ("updated", {"value": 1}),
+            ],
+        )
+
+        counter_logs = [
+            entry
+            for entry in history
+            if entry["name"] == "MODULE_LEVEL_COUNTER"
+        ]
+
+        init_log = next(
+            entry
+            for entry in counter_logs
+            if entry["event"] == "init"
+        )
+        updated_log = next(
+            entry
+            for entry in counter_logs
+            if entry["event"] == "updated"
+        )
+
+        self.assertEqual(init_log["var_id"], init_log["call_id"])
+        self.assertEqual(updated_log["var_id"], init_log["var_id"])
+        self.assertNotEqual(updated_log["call_id"], updated_log["var_id"])
 
     def test_register_stores_new_state_in_global_states(self):
         global MODULE_LEVEL_COUNTER

--- a/tests/test_trace_dispatcher_enclosing.py
+++ b/tests/test_trace_dispatcher_enclosing.py
@@ -16,6 +16,8 @@ def var_ids_for(history, name):
 def call_ids_for(history, name):
     return [entry["call_id"] for entry in history if entry["name"] == name]
 
+def domains_for(history, name):
+    return [entry["domain"] for entry in history if entry["name"] == name]
 
 class TestTraceDispatcherEnclosingIdentity(unittest.TestCase):
     def setUp(self):
@@ -43,6 +45,7 @@ class TestTraceDispatcherEnclosingIdentity(unittest.TestCase):
         events = events_for(history, "total")
         var_ids = var_ids_for(history, "total")
         call_ids = call_ids_for(history, "total")
+        domains = domains_for(history, "total")
 
         self.assertEqual(events, [("init", 0), ("updated", 1), ("updated", 2), ("updated", 3)])
         self.assertEqual(len(set(var_ids)), 1)
@@ -53,6 +56,10 @@ class TestTraceDispatcherEnclosingIdentity(unittest.TestCase):
         # yield a single updated event with a call_id of their own.
         self.assertEqual(call_ids[0], call_ids[1])
         self.assertEqual(len({call_ids[1], call_ids[2], call_ids[3]}), 3)
+
+        # ENCLOSING is an internal LEGB classification only; the log always
+        # reports the variable as LOCAL, never as "ENCLOSING".
+        self.assertTrue(all(domain == "LOCAL" for domain in domains))
 
     def test_different_outer_calls_get_different_var_ids(self):
         def outer():

--- a/tests/test_trace_dispatcher_enclosing.py
+++ b/tests/test_trace_dispatcher_enclosing.py
@@ -1,0 +1,200 @@
+import sys
+import unittest
+
+from oscilo.HistoryBuffer import HistoryBuffer
+from oscilo.TraceDispatcher import TraceDispatcher
+
+
+def events_for(history, name):
+    return [(entry["event"], entry["data"]) for entry in history if entry["name"] == name]
+
+
+def var_ids_for(history, name):
+    return [entry["var_id"] for entry in history if entry["name"] == name]
+
+
+def call_ids_for(history, name):
+    return [entry["call_id"] for entry in history if entry["name"] == name]
+
+
+class TestTraceDispatcherEnclosingIdentity(unittest.TestCase):
+    def setUp(self):
+        self.buffer = HistoryBuffer()
+        self.dispatcher = TraceDispatcher(self.buffer)
+
+    def tearDown(self):
+        self.dispatcher.stop()
+
+    def test_same_closure_called_repeatedly_keeps_same_var_id(self):
+        def outer():
+            total = 0
+            def inner():
+                nonlocal total
+                self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+            return inner
+
+        cb1 = outer()
+        cb1()
+        cb1()
+        cb1()
+
+        history = self.buffer.getHistory()
+        events = events_for(history, "total")
+        var_ids = var_ids_for(history, "total")
+        call_ids = call_ids_for(history, "total")
+
+        self.assertEqual(events, [("init", 0), ("updated", 1), ("updated", 2), ("updated", 3)])
+        self.assertEqual(len(set(var_ids)), 1)
+
+        # Each *call* to cb1 gets its own call_id; events produced within the
+        # same call share it. Here the 1st call yields two events (init +
+        # updated) sharing one call_id, while the 2nd and 3rd calls each
+        # yield a single updated event with a call_id of their own.
+        self.assertEqual(call_ids[0], call_ids[1])
+        self.assertEqual(len({call_ids[1], call_ids[2], call_ids[3]}), 3)
+
+    def test_different_outer_calls_get_different_var_ids(self):
+        def outer():
+            total = 0
+            def inner():
+                nonlocal total
+                self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+            return inner
+
+        cbA = outer()
+        cbB = outer()
+        cbA()
+        cbB()
+        cbA()
+        cbB()
+
+        history = self.buffer.getHistory()
+        entries = [entry for entry in history if entry["name"] == "total"]
+        var_ids = {entry["var_id"] for entry in entries}
+
+        # Two independent closures over the same code object must resolve to
+        # two distinct cells, so exactly two var_ids should appear.
+        self.assertEqual(len(var_ids), 2)
+
+        # Within each var_id's own events, the value sequence must be its own
+        # independent 0, 1, 2 count (each closure has its own cell), proving
+        # the two var_ids were not accidentally merged or cross-contaminated.
+        for var_id in var_ids:
+            data_sequence = [entry["data"] for entry in entries if entry["var_id"] == var_id]
+            self.assertEqual(data_sequence, [0, 1, 2])
+
+    def test_recursion_with_closure_keeps_var_id_and_advances_call_depth(self):
+        def make_counter():
+            total = 0
+            def inner(n):
+                nonlocal total
+                self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+                if n > 1:
+                    inner(n - 1)
+            return inner
+
+        counter = make_counter()
+        counter(3)
+
+        history = self.buffer.getHistory()
+        events = events_for(history, "total")
+        var_ids = var_ids_for(history, "total")
+        depths = [entry["call_depth"] for entry in history if entry["name"] == "total"]
+
+        self.assertEqual(events, [("init", 0), ("updated", 1), ("updated", 2), ("updated", 3)])
+        self.assertEqual(len(set(var_ids)), 1)
+        self.assertEqual(depths, [1, 1, 2, 3])
+
+    def test_closure_called_after_outer_has_returned(self):
+        def outer():
+            total = 0
+            def inner():
+                nonlocal total
+                self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+            return inner
+
+        callback = outer()
+        callback()
+        callback()
+
+        history = self.buffer.getHistory()
+        events = events_for(history, "total")
+        var_ids = var_ids_for(history, "total")
+
+        self.assertEqual(events, [("init", 0), ("updated", 1), ("updated", 2)])
+        self.assertEqual(len(set(var_ids)), 1)
+
+    def test_unregister_purges_enclosing_state_for_that_tracker(self):
+        def outer():
+            total = 0
+            def inner():
+                nonlocal total
+                tracker = self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+                return tracker
+            return inner
+
+        cb1 = outer()
+        tracker = cb1()
+        cb1()
+
+        self.assertIn(tracker, self.dispatcher._tracker_cells)
+        self.assertTrue(self.dispatcher._enclosing_var_ids)
+        self.assertTrue(self.dispatcher._enclosing_states)
+        self.assertTrue(self.dispatcher._enclosing_cell_refs)
+
+        self.dispatcher.unregister(tracker)
+
+        self.assertNotIn(tracker, self.dispatcher._tracker_cells)
+        self.assertEqual(self.dispatcher._enclosing_var_ids, {})
+        self.assertEqual(self.dispatcher._enclosing_states, {})
+        self.assertEqual(self.dispatcher._enclosing_cell_refs, {})
+
+    def test_stop_clears_all_enclosing_state(self):
+        def outer():
+            total = 0
+            def inner():
+                nonlocal total
+                self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+            return inner
+
+        cb1 = outer()
+        cb1()
+        cb1()
+
+        self.dispatcher.stop()
+
+        self.assertEqual(self.dispatcher._enclosing_var_ids, {})
+        self.assertEqual(self.dispatcher._enclosing_states, {})
+        self.assertEqual(self.dispatcher._enclosing_cell_refs, {})
+        self.assertEqual(self.dispatcher._frame_cell_cache, {})
+        self.assertEqual(self.dispatcher._tracker_cells, {})
+
+    def test_unresolvable_cell_falls_back_to_var_id_equal_call_id(self):
+        def make():
+            total = 0
+            def inner():
+                nonlocal total
+                self.dispatcher.register("total", frame=sys._getframe())
+                total += 1
+            return inner
+
+        # Never bound to a name in the caller's locals/globals, so the
+        # caller-frame heuristic cannot find the owning cell.
+        make()()
+
+        history = self.buffer.getHistory()
+        entries = [entry for entry in history if entry["name"] == "total"]
+
+        self.assertTrue(entries)
+        for entry in entries:
+            self.assertEqual(entry["var_id"], entry["call_id"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- 로그 각 이벤트에 `var_id`(변수 정체성) 필드를 추가한다. LOCAL/GLOBAL은 프레임/모듈 기준으로 안정적인 값을 부여하고, 이번 PR에서는 ENCLOSING(nonlocal) 변수까지 마저 처리해서 같은 클로저 인스턴스는 호출과 무관하게 항상 같은 `var_id`를 갖도록 만들었다.

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] `HistoryBuffer`/`TraceDispatcher`에 `var_id` 필드 추가 (LOCAL = 현재 프레임, GLOBAL = 최초 등록 프레임 기준 고정)
- [x] ENCLOSING 변수의 `var_id`를 실제 closure `cell` 객체 identity 기준으로 부여 → 같은 클로저를 여러 번 호출해도 `var_id` 유지, `call_id`만 호출마다 갱신
- [x] `outer()` 반환 후 클로저를 호출하는 경우, 재귀와 클로저가 함께 있는 경우까지 `var_id` 정합성 확보
- [x] 로그에 기록되는 `domain`은 내부적으로는 `ENCLOSING`을 그대로 유지하되(cell 기반 라우팅 판단에 사용), 외부 로그 출력 시점에는 항상 `LOCAL`로 통일해서 내보냄 
- [x] `unregister()`/`stop()` 시 cell 기반 상태(`_enclosing_var_ids`, `_enclosing_states`, `_enclosing_cell_refs`, `_tracker_cells`) 누수 없이 정리
- [x] 관련 테스트 추가 (`test_trace_dispatcher_enclosing.py`) — 반복 호출, 서로 다른 outer 호출, 재귀+클로저, outer 반환 후 호출, unregister/stop 정리, 휴리스틱 실패 시 fallback, domain 출력 검증

## Issue Link
<!-- Link any related issues below. e.g., Closes #12 -->
- N/A

## Screenshots / Videos (Optional)
<!-- Attach any visual evidence, mockups, or demos if there are UI/UX changes. -->

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.