### PR TITLE
Hotfix/docs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -89,7 +89,7 @@ def run():
     del target                  # deleted (삭제)
 
 run()
-# 종료 시 이력이 ocilo.jsonl에 기록됨
+# 종료 시 이력이 oscilo.jsonl에 기록됨
 ```
 
 `oscilo.register()`를 여러 번 호출하면 각 변수가 동일한 모니터에 추가되며, 모든 이력은 하나의 출력 파일로 병합됩니다.
@@ -118,21 +118,22 @@ run()
 
 ## 출력 형식
 
-이력은 [JSON Lines](https://jsonlines.org/) 형식으로 기록됩니다(기본 파일명 `ocilo.jsonl`). 각 줄이 하나의 변화를 나타냅니다.
+이력은 [JSON Lines](https://jsonlines.org/) 형식으로 기록됩니다(기본 파일명 `oscilo.jsonl`). 각 줄이 하나의 변화를 나타냅니다.
 
 ```json
-{"name": "target", "data": [100, 200], "event": "init", "domain": "LOCAL", "line": 4, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
-{"name": "target", "data": [100, 200, 300], "event": "updated", "domain": "LOCAL", "line": 6, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
-{"name": "target", "data": "reassigned", "event": "updated", "domain": "LOCAL", "line": 7, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
-{"name": "target", "data": null, "event": "deleted", "domain": "LOCAL", "line": 8, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": [100, 200], "event": "init", "domain": "LOCAL", "line": 4, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": [100, 200, 300], "event": "updated", "domain": "LOCAL", "line": 6, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": "reassigned", "event": "updated", "domain": "LOCAL", "line": 7, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": null, "event": "deleted", "domain": "LOCAL", "line": 8, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
 ```
 
 | 필드 | 설명 |
 |------|------|
 | `name` | 추적 중인 변수 이름 |
+| `var_id` | 추적 대상 변수의 정체성; 같은 `var_id`를 가진 기록은 동일한 변수를 가리킴 (지역 변수는 `call_id`와 동일, 전역·클로저 변수는 프레임이 바뀌어도 유지) |
 | `data` | 변화 시점의 값 (`deleted`일 때는 `null`) |
 | `event` | `init`, `updated`, `deleted` |
-| `domain` | 변수 스코프: `LOCAL`, `GLOBAL`, `ENCLOSING`, `UNKNOWN` |
+| `domain` | 변수 스코프: `LOCAL` 또는 `GLOBAL` (클로저(enclosing) 변수는 소유 프레임 관점에서 `LOCAL`로 기록되며, `var_id`로 식별됨) |
 | `line` | 변화가 감지된 소스 코드 줄 번호 |
 | `func` | 변화가 일어난 함수 이름 (모듈 최상위는 `<module>`) |
 | `call_id` | 변화가 일어난 함수 호출(프레임)의 고유 번호 |
@@ -168,11 +169,12 @@ run()
 src/oscilo/
 ├── __init__.py          # 공개 API(register)와 단일 인스턴스 관리
 ├── _core.py             # 모니터 구현 및 atexit 저장 로직
+├── CallContext.py       # 지연 생성 호출 컨텍스트 추적 (call_id / parent_call_id / call_depth)
 ├── FileWriter.py        # JSONL 출력
 ├── HistoryBuffer.py     # 메모리 내 이력 버퍼
 ├── ScopeResolver.py     # LEGB 스코프 해석 (지역/둘러싼/전역/내장)
 ├── TraceDispatcher.py   # sys.settrace 이벤트 처리
-├── VariableTracker.py   # 변수별 상태 및 스냅샷
+├── VariableTracker.py   # 변수별 변화 감지 및 값 스냅샷
 └── oscilo_engine.c      # 값 비교를 담당하는 C 확장 모듈
 ```
 
@@ -182,7 +184,7 @@ src/oscilo/
 python tests/test.py
 ```
 
-`tests/`에서 `test_*.py`를 자동으로 찾아 실행합니다. 각 시나리오는 별도 인터프리터 프로세스로 실행되는데, `atexit` 기반 저장과 `sys.settrace` 동작은 전체 프로세스 생명주기에 걸쳐야만 검증할 수 있기 때문입니다.
+`tests/`에서 `test_*.py`를 자동으로 찾아 실행합니다. 컴포넌트 테스트는 같은 프로세스 안에서 실행되고, 엔드투엔드 시나리오(등록·프로세스 생명주기)는 별도 인터프리터 프로세스를 띄웁니다. `atexit` 기반 저장과 `sys.settrace` 동작은 전체 프로세스 생명주기에 걸쳐야만 검증할 수 있기 때문입니다.
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ def run():
     del target                  # deleted
 
 run()
-# On exit, the history is written to ocilo.jsonl
+# On exit, the history is written to oscilo.jsonl
 ```
 
 Calling `oscilo.register()` multiple times adds each variable to the same monitor, and all histories are merged into a single output file:
@@ -118,21 +118,22 @@ Notes:
 
 ## Output format
 
-History is written as [JSON Lines](https://jsonlines.org/) (`ocilo.jsonl` by default). Each line represents a single change:
+History is written as [JSON Lines](https://jsonlines.org/) (`oscilo.jsonl` by default). Each line represents a single change:
 
 ```json
-{"name": "target", "data": [100, 200], "event": "init", "domain": "LOCAL", "line": 4, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
-{"name": "target", "data": [100, 200, 300], "event": "updated", "domain": "LOCAL", "line": 6, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
-{"name": "target", "data": "reassigned", "event": "updated", "domain": "LOCAL", "line": 7, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
-{"name": "target", "data": null, "event": "deleted", "domain": "LOCAL", "line": 8, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": [100, 200], "event": "init", "domain": "LOCAL", "line": 4, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": [100, 200, 300], "event": "updated", "domain": "LOCAL", "line": 6, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": "reassigned", "event": "updated", "domain": "LOCAL", "line": 7, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
+{"name": "target", "var_id": 1, "data": null, "event": "deleted", "domain": "LOCAL", "line": 8, "func": "run", "call_id": 1, "parent_call_id": null, "call_depth": 1}
 ```
 
 | Field | Description |
 |-------|-------------|
 | `name` | The tracked variable name |
+| `var_id` | Identity of the tracked binding; records sharing a `var_id` refer to the same variable (matches `call_id` for locals; stays stable across frames for globals and closure variables) |
 | `data` | The value at the time of the change (`null` for `deleted`) |
 | `event` | `init`, `updated`, or `deleted` |
-| `domain` | Variable scope: `LOCAL`, `GLOBAL`, `ENCLOSING`, or `UNKNOWN` |
+| `domain` | Variable scope: `LOCAL` or `GLOBAL` (a closure/enclosing variable is reported as `LOCAL` from its owning frame's point of view and is identified by `var_id`) |
 | `line` | Source line where the change was detected |
 | `func` | Function in which the change occurred (`<module>` at module level) |
 | `call_id` | Unique id of the function call (frame) where the change occurred |
@@ -168,11 +169,12 @@ Unchanged values produce no record, and immutable values are skipped entirely wh
 src/oscilo/
 ├── __init__.py          # public API (register) and single-instance management
 ├── _core.py             # monitor implementation and atexit save logic
+├── CallContext.py       # lazy call-context tracking (call_id / parent_call_id / call_depth)
 ├── FileWriter.py        # JSONL output
 ├── HistoryBuffer.py     # in-memory history buffer
 ├── ScopeResolver.py     # LEGB scope resolution (local/enclosing/global/builtin)
 ├── TraceDispatcher.py   # sys.settrace event handling
-├── VariableTracker.py   # per-variable state and snapshots
+├── VariableTracker.py   # per-variable change detection and value snapshots
 └── oscilo_engine.c      # C extension for value comparison
 ```
 
@@ -182,7 +184,7 @@ src/oscilo/
 python tests/test.py
 ```
 
-Tests are discovered from `tests/` (`test_*.py`). Each scenario runs in a separate interpreter process, since `atexit`-driven saving and `sys.settrace` behavior can only be verified across a full process lifetime.
+Tests are discovered from `tests/` (`test_*.py`). Component tests run in-process, while the end-to-end scenarios (registration and process lifecycle) spawn a separate interpreter process, since `atexit`-driven saving and `sys.settrace` behavior can only be verified across a full process lifetime.
 
 ## Contributing
 

--- a/src/oscilo/_core.py
+++ b/src/oscilo/_core.py
@@ -7,7 +7,7 @@ from .TraceDispatcher import TraceDispatcher
 
 
 class _Oscilo:
-    def __init__(self, fileName="ocilo.jsonl"):
+    def __init__(self, fileName="oscilo.jsonl"):
         self.fileName = fileName
         self.buffer = HistoryBuffer()
         self.dispatcher = TraceDispatcher(self.buffer)

--- a/tests/test_log_register.py
+++ b/tests/test_log_register.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import oscilo
 
-DEFAULT_LOG_NAME = "ocilo.jsonl"
+DEFAULT_LOG_NAME = "oscilo.jsonl"
 
-# Resolve the directory that contains the ocilo package so subprocess scenarios
+# Resolve the directory that contains the oscilo package so subprocess scenarios
 # import the same package regardless of src layout or installed layout.
 PACKAGE_PARENT = Path(oscilo.__file__).resolve().parents[1]
 
@@ -39,7 +39,7 @@ def run_scenario(test_case, temp_dir, source):
 
 def read_default_log(test_case, temp_dir):
     log_path = os.path.join(temp_dir, DEFAULT_LOG_NAME)
-    test_case.assertTrue(os.path.exists(log_path), "expected ocilo.jsonl to be written")
+    test_case.assertTrue(os.path.exists(log_path), "expected oscilo.jsonl to be written")
 
     with open(log_path, "r", encoding="utf-8") as file:
         return [json.loads(line) for line in file]
@@ -114,7 +114,7 @@ class TestRegisterPublicAPI(unittest.TestCase):
             self.assertFalse(os.path.exists(os.path.join(temp_dir, DEFAULT_LOG_NAME)))
 
     def test_public_api_surface(self):
-        # Importing ocilo is side-effect free, so this check can run in-process.
+        # Importing oscilo is side-effect free, so this check can run in-process.
         self.assertEqual(oscilo.__all__, ["register"])
         self.assertTrue(callable(oscilo.register))
         self.assertFalse(hasattr(oscilo, "logger"))

--- a/tests/test_oscilo_process_lifecycle.py
+++ b/tests/test_oscilo_process_lifecycle.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
-DEFAULT_LOG_NAME = "ocilo.jsonl"
+DEFAULT_LOG_NAME = "oscilo.jsonl"
 EXPECTED_LOG_KEYS = {"name", "var_id", "data", "event", "domain", "line", "func", "call_id", "parent_call_id", "call_depth", }
 TRACKING_EVENTS = {"init", "updated", "deleted"}
 TRACKING_DOMAINS = {"LOCAL", "GLOBAL"}
@@ -26,7 +26,7 @@ def build_pythonpath():
 
 def run_python_script(script, cwd):
     # Run the sample program in a separate process to exercise atexit behavior.
-    # cwd is the script's own temp directory so the default "ocilo.jsonl" output
+    # cwd is the script's own temp directory so the default "oscilo.jsonl" output
     # lands there instead of polluting the project root.
     script_path = os.path.join(cwd, "sample_program.py")
 


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- v1.0.0 릴리스 전 문서/코드 정합성을 맞추는 hotfix
- 기본 출력 파일명 오타 수정(ocilo.jsonl → oscilo.jsonl) 및 README(영/한)를 실제 oscilo API·출력 형식과 동기화

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] _core.py 기본 출력 파일명 오타 수정: ocilo.jsonl → oscilo.jsonl
- [x] README 출력 형식에 var_id 필드 반영 (JSON 예시 + 필드 표)
- [x] domain 값 정정: LOCAL / GLOBAL (ENCLOSING·UNKNOWN 제거, 클로저 변수는 LOCAL로 기록되며 var_id로 식별)
- [x] Project Layout에 누락된 CallContext.py 추가
- [x] Testing 설명 정정: 컴포넌트 테스트는 in-process, 엔드투엔드 시나리오만 별도 인터프리터 프로세스
- [x] VariableTracker.py 설명을 무상태 리팩터링 이후에 맞게 갱신
- [x] 위 변경을 영어(README.md)·한국어(README.ko.md) 양쪽에 동일 반영

---

## Checklist
- [X] My code follows the coding style and guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have verified and tested the changes successfully.
- [X] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.