### PR TITLE
CI: bootstrap GitFlow workflows onto master (files only)

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,126 @@
+name: Cut Release Branch
+
+# Trigger 1 (GitFlowPipeline.md §1): when a feature/* PR merges into develop,
+# automatically cut release/vX.Y.Z from develop. No tag is created yet — the tag
+# and the master/develop merges wait for the manual "Finish release" (finalize.yml).
+#
+# IMPORTANT: trigger on `pull_request: closed` with a feature/* head — NOT on
+# `push: develop`. A push trigger would also fire on the release→develop back-merge
+# and cut releases forever.
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+jobs:
+  cut-release:
+    name: Cut release branch
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'feature/') }}
+    permissions:
+      contents: write        # create the release/* ref
+      pull-requests: read
+    steps:
+      # Guard: strict 1:1 (Key Point 4) should already prevent this, but never cut
+      # a second release if one is somehow open.
+      - name: Ensure no release/hotfix is already open
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const open = [];
+            for (const prefix of ['heads/release/', 'heads/hotfix/']) {
+              const refs = await github.rest.git.listMatchingRefs({ owner, repo, ref: prefix });
+              open.push(...refs.data.map(r => r.ref.replace('refs/heads/', '')));
+            }
+            if (open.length > 0) {
+              core.warning(`release/hotfix already open: [${open.join(', ')}]. Skipping cut.`);
+              core.setOutput('skip', 'true');
+            } else {
+              core.setOutput('skip', 'false');
+            }
+
+      # per-feature model → exactly one bump label on the feature PR (enforced by the
+      # Verify Version Label required check). Read it straight from the PR payload.
+      - name: Determine bump from PR label
+        if: ${{ steps.guard.outputs.skip == 'false' }}
+        id: bump
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const bumps = ['major', 'minor', 'patch'];
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const present = labels.filter(n => bumps.includes(n));
+            if (present.length !== 1) {
+              core.setFailed(`Expected exactly one of major/minor/patch, found [${present.join(', ')}].`);
+              return;
+            }
+            core.setOutput('bump', present[0]);
+
+      - name: Checkout develop (post-merge tip)
+        if: ${{ steps.guard.outputs.skip == 'false' }}
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0        # need full history + tags for git describe
+
+      # Version base = the tag topologically reachable from develop, NOT the highest
+      # numeric tag. The repo carries an orphan v1.4.0 (pre-rename) that must be
+      # ignored; after the bootstrap sync, develop's reachable tag is v1.0.0.
+      - name: Compute next version
+        if: ${{ steps.guard.outputs.skip == 'false' }}
+        id: ver
+        shell: bash
+        env:
+          BUMP: ${{ steps.bump.outputs.bump }}
+        run: |
+          set -euo pipefail
+          base="$(git describe --tags --abbrev=0)"
+          echo "base tag reachable from develop: $base"
+          ver="${base#v}"
+          IFS='.' read -r X Y Z <<< "$ver"
+          case "$BUMP" in
+            major) X=$((X+1)); Y=0; Z=0 ;;
+            minor) Y=$((Y+1)); Z=0 ;;
+            patch) Z=$((Z+1)) ;;
+            *) echo "unknown bump: $BUMP" >&2; exit 1 ;;
+          esac
+          next="v${X}.${Y}.${Z}"
+          echo "next version: $next"
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch with an opening commit
+        if: ${{ steps.guard.outputs.skip == 'false' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ steps.ver.outputs.version }}';
+            const { owner, repo } = context.repo;
+            const dev = await github.rest.git.getRef({ owner, repo, ref: 'heads/develop' });
+            const parent = dev.data.object.sha;
+            const parentCommit = await github.rest.git.getCommit({ owner, repo, commit_sha: parent });
+
+            // Put an empty commit (same tree as develop tip) on the release branch so it
+            // always has at least one commit beyond develop. Otherwise, if no
+            // stabilization fixes are added, the release→develop back-merge PR would have
+            // no diff and cannot be opened (GitHub 422), stalling finalize/post-merge.
+            // The tag later lands on this commit, making it the shared ancestor of
+            // master and develop.
+            const commit = await github.rest.git.createCommit({
+              owner, repo,
+              message: `chore(release): open ${version}\n\nStabilization branch cut from develop. Add fixes here, then run "Finish release".`,
+              tree: parentCommit.data.tree.sha,
+              parents: [parent],
+            });
+            const branch = `release/${version}`;
+            try {
+              await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: commit.data.sha });
+              core.notice(`Created ${branch} at ${commit.data.sha.slice(0, 7)} (opening commit). Run "Finish release" when stabilized.`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.warning(`Branch ${branch} already exists — skipping creation.`);
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -1,0 +1,119 @@
+name: Finish Release / Hotfix
+
+# Manual finalize signal (GitFlowPipeline.md §2 and §3). One human decision — "ship
+# it" — then everything is unattended:
+#   1. tag vX.Y.Z at the release/hotfix tip
+#   2. open branch→master and branch→develop PRs (App token, so test.yml triggers)
+#   3. enable auto-merge on both (Ruleset A bypasses approval for the App)
+# The GitHub Release + branch deletion happen later in post-merge.yml, only after
+# BOTH PRs merge (§2 note: 2→3 is not a synchronous continuation).
+#
+# Both release/vX.Y.Z and hotfix/vX.Y.Z encode the target version in the branch
+# name, so no version computation is needed here.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "release/* or hotfix/* branch to finalize (blank = auto-detect the single open one)"
+        required: false
+        default: ""
+
+jobs:
+  finalize:
+    name: Tag and open merge PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Tag, open PRs, enable auto-merge
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+
+            // --- Resolve the branch to finalize -------------------------------
+            let branch = (context.payload.inputs.branch || '').trim();
+            if (!branch) {
+              const open = [];
+              for (const prefix of ['heads/release/', 'heads/hotfix/']) {
+                const refs = await github.rest.git.listMatchingRefs({ owner, repo, ref: prefix });
+                open.push(...refs.data.map(r => r.ref.replace('refs/heads/', '')));
+              }
+              if (open.length !== 1) {
+                core.setFailed(`Expected exactly one open release/hotfix, found ${open.length}: [${open.join(', ')}]. Pass 'branch' explicitly.`);
+                return;
+              }
+              branch = open[0];
+            }
+            if (!/^(release|hotfix)\//.test(branch)) {
+              core.setFailed(`branch '${branch}' must start with release/ or hotfix/.`);
+              return;
+            }
+
+            // --- Version from branch name -------------------------------------
+            const m = branch.match(/(v\d+\.\d+\.\d+)$/);
+            if (!m) {
+              core.setFailed(`Cannot parse vX.Y.Z from branch '${branch}'.`);
+              return;
+            }
+            const version = m[1];
+
+            // --- Tag the branch tip -------------------------------------------
+            const ref = await github.rest.git.getRef({ owner, repo, ref: `heads/${branch}` });
+            const sha = ref.data.object.sha;
+            try {
+              await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${version}`, sha });
+              core.notice(`Tagged ${version} at ${sha.slice(0, 7)}.`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.warning(`Tag ${version} already exists — continuing.`);
+              } else {
+                throw e;
+              }
+            }
+
+            // --- Open the two merge PRs (body has ZERO unchecked '- [ ]' boxes
+            //     so check-pr-checklist passes) ---------------------------------
+            const kind = branch.startsWith('hotfix/') ? 'Hotfix' : 'Release';
+            const bodyFor = (base) =>
+              `Automated ${kind.toLowerCase()} merge of \`${branch}\` (${version}) into \`${base}\`.\n\n` +
+              `Code was reviewed and CI-verified at feature→develop. This PR merges unattended via auto-merge.`;
+
+            async function openPr(base) {
+              const existing = await github.rest.pulls.list({
+                owner, repo, state: 'open', head: `${owner}:${branch}`, base,
+              });
+              let pr = existing.data[0];
+              if (!pr) {
+                const created = await github.rest.pulls.create({
+                  owner, repo, head: branch, base,
+                  title: `${kind} ${version} → ${base}`,
+                  body: bodyFor(base),
+                });
+                pr = created.data;
+                core.notice(`Opened ${branch} → ${base} (#${pr.number}).`);
+              } else {
+                core.notice(`Reusing existing ${branch} → ${base} (#${pr.number}).`);
+              }
+              // Enable auto-merge (Ruleset A bypasses approval for the App; Ruleset B
+              // still requires CI green before this merges).
+              await github.graphql(
+                `mutation($id: ID!) {
+                   enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: MERGE }) {
+                     pullRequest { number }
+                   }
+                 }`,
+                { id: pr.node_id }
+              );
+              core.info(`Auto-merge enabled on #${pr.number}.`);
+            }
+
+            await openPr('master');
+            await openPr('develop');
+            core.notice(`Finalize complete for ${version}. Release + branch cleanup run after both PRs merge.`);

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,86 @@
+name: Post-merge Release
+
+# GitFlowPipeline.md §2 step 3-4 (and §3 for hotfix). Fires when a release/* or
+# hotfix/* PR merges into master OR develop. It waits until BOTH the →master and
+# →develop PRs for that branch are merged, then:
+#   1. creates the GitHub Release (→ publish.yml → PyPI)
+#   2. deletes the branch (which releases the Serialize Guard for the next feature)
+#
+# Ordering matters (§2 note): delete ONLY after both merge, else an open back-merge
+# PR whose head is deleted closes as unmerged and the back-merge is lost.
+on:
+  pull_request:
+    types: [closed]
+    branches: [master, develop]
+
+# Both merge events can fire near-simultaneously; serialize per-branch and keep the
+# actions idempotent so we create one Release and delete once.
+concurrency:
+  group: post-merge-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-and-cleanup:
+    name: Release and cleanup
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')) }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Release when both PRs merged, then delete branch
+        uses: actions/github-script@v7
+        with:
+          # App token so `release: published` actually triggers publish.yml — a
+          # Release created with GITHUB_TOKEN would NOT trigger it.
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.payload.pull_request.head.ref;
+
+            const version = (branch.match(/(v\d+\.\d+\.\d+)$/) || [])[1];
+            if (!version) {
+              core.setFailed(`Cannot parse vX.Y.Z from branch '${branch}'.`);
+              return;
+            }
+
+            // --- Require BOTH →master and →develop PRs to be merged ------------
+            const all = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'all', head: `${owner}:${branch}`, per_page: 100,
+            });
+            const mergedInto = (base) => all.some(p => p.base.ref === base && p.merged_at);
+            if (!mergedInto('master') || !mergedInto('develop')) {
+              core.notice(`Waiting: master merged=${mergedInto('master')}, develop merged=${mergedInto('develop')}. Exiting; the other merge will re-trigger.`);
+              return;
+            }
+
+            // --- Create the GitHub Release (idempotent) -----------------------
+            try {
+              await github.rest.repos.createRelease({
+                owner, repo, tag_name: version, name: version,
+                generate_release_notes: true,
+              });
+              core.notice(`Published GitHub Release ${version}.`);
+            } catch (e) {
+              if (e.status === 422) {
+                core.warning(`Release ${version} already exists — skipping.`);
+              } else {
+                throw e;
+              }
+            }
+
+            // --- Delete the branch (idempotent), only now that both merged ----
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `heads/${branch}` });
+              core.notice(`Deleted ${branch}. Serialize Guard is now clear for the next feature.`);
+            } catch (e) {
+              if (e.status === 422 || e.status === 404) {
+                core.warning(`Branch ${branch} already deleted — skipping.`);
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [ develop, master ]
 
 jobs:
@@ -18,6 +18,71 @@ jobs:
             const unchecked = (body.match(/^- \[ \]/gm) || []).length;
             if (unchecked > 0) {
               core.setFailed(`${unchecked} checklist item(s) unchecked. Complete all items before merging.`);
+            }
+
+  # Required check. MUST always report a status (never skip the job), otherwise a
+  # non-feature PR (docs/*, chore/*, release/* back-merge) would sit forever as
+  # "pending" and auto-merge would never fire. The feature/* gate lives INSIDE the
+  # script so non-target heads pass immediately. See GitFlowPipeline.md Key Point 1.
+  version-label:
+    name: Verify Version Label
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require exactly one version label on feature PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const head = context.payload.pull_request.head.ref;
+            if (!head.startsWith('feature/')) {
+              core.info(`head '${head}' is not feature/*, version label not required.`);
+              return;
+            }
+            const bumps = ['major', 'minor', 'patch'];
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const present = labels.filter(n => bumps.includes(n));
+            if (present.length !== 1) {
+              core.setFailed(
+                `feature/* PR needs exactly one of major/minor/patch (found ${present.length}: ` +
+                `[${present.join(', ')}]). Add exactly one bump label.`
+              );
+            } else {
+              core.info(`bump label = ${present[0]}`);
+            }
+
+  # Required check enforcing the strict-1:1 serialization: no feature may merge
+  # while a release/* or hotfix/* is open. Same "always run, gate inside script"
+  # rule as above. Stale-green is closed by the Ruleset "Require branches to be up
+  # to date". See GitFlowPipeline.md Key Point 4.
+  serialize-guard:
+    name: Serialize Guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # listMatchingRefs (git refs) needs contents:read
+    steps:
+      - name: Block feature merge while a release/hotfix is open
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const head = context.payload.pull_request.head.ref;
+            if (!head.startsWith('feature/')) {
+              core.info(`head '${head}' is not feature/*, serialization gate skipped.`);
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const open = [];
+            for (const prefix of ['heads/release/', 'heads/hotfix/']) {
+              const refs = await github.rest.git.listMatchingRefs({ owner, repo, ref: prefix });
+              open.push(...refs.data.map(r => r.ref.replace('refs/heads/', '')));
+            }
+            if (open.length > 0) {
+              core.setFailed(
+                `A release/hotfix is in progress: [${open.join(', ')}]. ` +
+                `Wait until it is finalized and its branch is deleted before merging.`
+              );
+            } else {
+              core.info('No open release/hotfix. Feature may proceed.');
             }
 
   test:


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- 릴리스 파이프라인 워크플로 파일만 master에 심는다.
- finalize(default 브랜치에 있어야 실행 가능)와 post-merge(병합 시 base 브랜치 파일로 동작)가 첫 릴리스 전에 master에 존재해야 하기 때문이다.
- develop 미출시 내용은 포함하지 않는다.

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] `cut-release.yml`·`finalize.yml`·`post-merge.yml` 신규 추가
- [x] `test.yml`: 가드 잡 2종 + 트리거 반영 (develop과 동일 버전으로 정렬)
- [x] 워크플로 파일만 포함 — 코드/문서 변경 없음

## Issue Link
<!-- Link any related issues below. e.g., Closes #12 -->
- Closes #49 

---

## Checklist
- [X] My code follows the coding style and guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have verified and tested the changes successfully.
- [X] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.