### PR TITLE
Feature/ancestor frame tracking

### DIFF
--- a/docs/FrameAttachment.md
+++ b/docs/FrameAttachment.md
@@ -2,7 +2,7 @@
 
 `TraceDispatcher`가 어떤 프레임에 라인 트레이싱을 걸지 결정하는 방식을 정리한다.
 
-관련 코드: `TraceDispatcher._trace_calls`, `_ensure_frame_tracking`, `_make_line_tracer`, `register`
+관련 코드: `TraceDispatcher._trace_calls`, `_ensure_frame_tracking`, `_ensure_active_ancestor_tracking`, `_make_line_tracer`, `register`
 
 ---
 
@@ -35,7 +35,9 @@ frame_state = self._ensure_frame_tracking(frame) #TrcerDispathcer.py - line 260
 
 추적 가능 기준은 스택상의 위치가 아니라 **`sys.settrace` 호출 시점 대비 프레임의 생성 시점**이다.
 
-수동 부착은 등록 프레임 **하나**만 대상으로 한다. 즉 register 이전부터 실행 중이던 조상 프레임은 수동 부착 대상이 아니며, 그 안에서 일어나는 변경은 잡히지 않는다. 추적하려는 변수가 등록 프레임에 있다는 전제에 기댄 선택이다.
+수동 부착은 등록 프레임에서 끝나지 않는다. 등록 프레임의 지역 변수를 shadowing 없이 참조할 수 있는 조상 프레임(같은 code 객체를 재귀 중인 프레임, 또는 같은 globals dict를 쓰는 프레임)에서 일어나는 변경도 잡아야 하므로, `register()`는 `_ensure_active_ancestor_tracking(frame)`으로 `frame.f_back`을 거슬러 올라가며 각 조상에 대해 `_relevant_for()`로 관련 여부를 판정하고, 관련 있는 프레임에만 라인 트레이서를 붙인다.
+
+이 탐색은 무한정 올라가지 않는다. `co_name == "<module>"`인 프레임을 만나면 그 프레임까지는 처리하고 즉시 멈춘다. `<module>` 프레임은 이 실행 단위(대상 파일, 하나의 `exec()` 호출, 하나의 Jupyter 셀)의 최상단이기 때문이다. 여기서 멈추지 않으면, 같은 globals dict를 재사용하는 무관한 실행 단위(중첩 `exec()`, 노트북 셀 러너)나 이 코드를 호출한 인터프리터/테스트 러너 프레임까지 관련 있다고 잘못 판정해 추적을 붙이게 된다.
 
 ## 라인 트레이서를 프레임마다 새로 만드는 이유
 

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -258,6 +258,7 @@ class TraceDispatcher:
         # line tracing을 여기서 명시적으로 붙여야 한다(또는 이전 등록/호출에서
         # 이미 붙어 있다면 그것을 재사용한다).
         frame_state = self._ensure_frame_tracking(frame)
+        self._ensure_active_ancestor_tracking(frame)
 
         if self._is_enclosing_case(resolved_domain, tracker):
             self._check_and_log_enclosing(frame, tracker, varName)
@@ -491,6 +492,19 @@ class TraceDispatcher:
         self._frame_states[frame] = frame_state
         frame.f_trace = self._make_line_tracer(frame_state)
         return frame_state
+
+    def _ensure_active_ancestor_tracking(self, frame):
+        current_frame = frame.f_back
+
+        while current_frame is not None:
+            local_relevant, global_relevant = self._relevant_for(
+                current_frame
+            )
+
+            if local_relevant or global_relevant:
+                self._ensure_frame_tracking(current_frame)
+
+            current_frame = current_frame.f_back
 
     def _trace_calls(self, frame, event, arg):
         if event != "call":

--- a/src/oscilo/TraceDispatcher.py
+++ b/src/oscilo/TraceDispatcher.py
@@ -504,6 +504,13 @@ class TraceDispatcher:
             if local_relevant or global_relevant:
                 self._ensure_frame_tracking(current_frame)
 
+            # <module> frame은 이 실행 단위(파일, exec() 호출, Jupyter 셀 등)의
+            # 최상단이다. 여기서 멈추지 않으면, 같은 globals dict를 재사용하는
+            # 무관한 실행 단위(중첩 exec, 노트북 셀 러너 등)나 이 파일을 호출한
+            # 인터프리터/테스트 러너 frame까지 조상으로 착각해 추적을 붙이게 된다.
+            if current_frame.f_code.co_name == "<module>":
+                break
+
             current_frame = current_frame.f_back
 
     def _trace_calls(self, frame, event, arg):

--- a/tests/test_log_register.py
+++ b/tests/test_log_register.py
@@ -141,6 +141,46 @@ class TestRegisterPublicAPI(unittest.TestCase):
         self.assertEqual(a_entries[-1]["domain"], "GLOBAL")
         self.assertEqual(a_entries[-1]["func"], "<module>")
 
+    def test_global_update_in_active_parent_function_is_tracked(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_scenario(self, temp_dir, """
+                import oscilo
+
+                A = 10
+
+                def outer():
+                    global A
+
+                    def register_a():
+                        oscilo.register("A")
+
+                    register_a()
+                    A = 20
+
+                    checkpoint = "after parent update"
+                    print(checkpoint)
+
+                outer()
+            """)
+
+            entries = read_default_log(self, temp_dir)
+
+        a_entries = [
+            entry
+            for entry in entries
+            if entry["name"] == "A"
+        ]
+
+        self.assertEqual(
+            events_for(entries, "A"),
+            [
+                ("init", 10),
+                ("updated", 20),
+            ],
+        )
+        self.assertEqual(a_entries[-1]["domain"], "GLOBAL")
+        self.assertEqual(a_entries[-1]["func"], "outer")
+
     def test_import_only_leaves_no_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             run_scenario(self, temp_dir, "import oscilo\n")

--- a/tests/test_log_register.py
+++ b/tests/test_log_register.py
@@ -97,6 +97,50 @@ class TestRegisterPublicAPI(unittest.TestCase):
         self.assertEqual(events_for(entries, "A"), [("init", 1), ("updated", 2)])
         self.assertEqual(events_for(entries, "B"), [("init", 10), ("updated", 20)])
 
+    def test_global_update_in_active_module_frame_is_tracked(self):
+        # Regression for issue #39: sys.settrace() does not retroactively
+        # attach line tracing to module frames that were already active when
+        # register() was called from a child frame.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_scenario(self, temp_dir, """
+                import oscilo
+
+                A = 10
+
+                def register_a():
+                    oscilo.register("A")
+
+                def update_a():
+                    global A
+                    A = 11
+
+                register_a()
+                update_a()
+                A = 12
+
+                checkpoint = "after module update"
+                print(checkpoint)
+            """)
+
+            entries = read_default_log(self, temp_dir)
+
+        a_entries = [
+            entry
+            for entry in entries
+            if entry["name"] == "A"
+        ]
+
+        self.assertEqual(
+            events_for(entries, "A"),
+            [
+                ("init", 10),
+                ("updated", 11),
+                ("updated", 12),
+            ],
+        )
+        self.assertEqual(a_entries[-1]["domain"], "GLOBAL")
+        self.assertEqual(a_entries[-1]["func"], "<module>")
+
     def test_import_only_leaves_no_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             run_scenario(self, temp_dir, "import oscilo\n")

--- a/tests/test_trace_dispatcher.py
+++ b/tests/test_trace_dispatcher.py
@@ -71,6 +71,53 @@ class TestTraceDispatcherFrameRelevance(unittest.TestCase):
 
         self.assertEqual(ancestor_tracking, [False])
 
+    def test_active_ancestor_tracking_stops_at_module_frame_boundary(self):
+        # A nested exec() that reuses this module's globals() dict (the same
+        # pattern a Jupyter cell or a dynamic-code loader uses) creates a
+        # second "<module>" frame sharing globals identity with this test's
+        # own frame. Ancestor tracking must stop once it reaches that nested
+        # <module> frame instead of climbing past it into the real caller,
+        # which only happens to share the same globals dict by coincidence.
+        # Membership is checked while each frame is still on the stack,
+        # since return-cleanup would otherwise pop it before we can inspect it.
+        global MODULE_LEVEL_COUNTER
+        MODULE_LEVEL_COUNTER = {"value": 0}
+        tracked = {}
+
+        def register_global():
+            self.dispatcher.register(
+                "MODULE_LEVEL_COUNTER",
+                frame=sys._getframe(),
+            )
+
+        exec_globals = globals()
+        exec_globals["_boundary_test_register"] = register_global
+        exec_globals["_boundary_test_tracked"] = tracked
+        exec_globals["_boundary_test_dispatcher"] = self.dispatcher
+        source = (
+            "import sys\n"
+            "def _nested_caller():\n"
+            "    _boundary_test_register()\n"
+            "    _boundary_test_tracked['nested_caller'] = ("
+            "sys._getframe() in _boundary_test_dispatcher._frame_states)\n"
+            "_nested_caller()\n"
+            "_boundary_test_tracked['module'] = ("
+            "sys._getframe() in _boundary_test_dispatcher._frame_states)\n"
+        )
+
+        try:
+            exec(compile(source, "<ancestor-boundary-test>", "exec"), exec_globals)
+        finally:
+            del exec_globals["_boundary_test_register"]
+            del exec_globals["_boundary_test_tracked"]
+            del exec_globals["_boundary_test_dispatcher"]
+
+        caller_tracked = sys._getframe() in self.dispatcher._frame_states
+
+        self.assertTrue(tracked["nested_caller"])
+        self.assertTrue(tracked["module"])
+        self.assertFalse(caller_tracked)
+
     def test_unresolved_registration_spreads_relevance_across_module_frames(self):
         # A registration whose variable does not exist anywhere yet cannot be
         # scoped to a single code object in advance (we don't know which

--- a/tests/test_trace_dispatcher.py
+++ b/tests/test_trace_dispatcher.py
@@ -43,6 +43,34 @@ class TestTraceDispatcherFrameRelevance(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    def test_active_ancestor_with_shadowing_local_is_not_traced(self):
+        global MODULE_LEVEL_COUNTER
+        MODULE_LEVEL_COUNTER = {"value": 0}
+        ancestor_tracking = []
+
+        def outer():
+            MODULE_LEVEL_COUNTER = "shadowed local"
+
+            def register_global():
+                self.dispatcher.register(
+                    "MODULE_LEVEL_COUNTER",
+                    frame=sys._getframe(),
+                )
+
+            register_global()
+
+            ancestor_tracking.append(
+                sys._getframe() in self.dispatcher._frame_states
+            )
+            self.assertEqual(
+                MODULE_LEVEL_COUNTER,
+                "shadowed local",
+            )
+
+        outer()
+
+        self.assertEqual(ancestor_tracking, [False])
+
     def test_unresolved_registration_spreads_relevance_across_module_frames(self):
         # A registration whose variable does not exist anywhere yet cannot be
         # scoped to a single code object in advance (we don't know which

--- a/tests/test_trace_dispatcher.py
+++ b/tests/test_trace_dispatcher.py
@@ -366,6 +366,9 @@ class TestTraceDispatcherStopCleanup(unittest.TestCase):
         self.buffer = HistoryBuffer()
         self.dispatcher = TraceDispatcher(self.buffer)
 
+    def tearDown(self):
+        self.dispatcher.stop()
+
     def test_stop_clears_call_context_and_frame_state(self):
         def recurse(n):
             acc = n
@@ -380,6 +383,79 @@ class TestTraceDispatcherStopCleanup(unittest.TestCase):
         self.assertEqual(self.dispatcher._context_manager._cleanup_traces, {})
         self.assertEqual(self.dispatcher._frame_states, {})
         self.assertEqual(self.dispatcher._trackers, [])
+
+    def test_active_ancestor_states_are_isolated_and_removed_on_return(self):
+        global MODULE_LEVEL_COUNTER
+        MODULE_LEVEL_COUNTER = {"value": 0}
+        returned_frames = []
+
+        def outer():
+            def register_global():
+                self.dispatcher.register(
+                    "MODULE_LEVEL_COUNTER",
+                    frame=sys._getframe(),
+                )
+
+            register_global()
+
+            outer_frame = sys._getframe()
+            parent_frame = outer_frame.f_back
+
+            self.assertIn(
+                outer_frame,
+                self.dispatcher._frame_states,
+            )
+            self.assertIn(
+                parent_frame,
+                self.dispatcher._frame_states,
+            )
+            self.assertIsNot(
+                self.dispatcher._frame_states[outer_frame],
+                self.dispatcher._frame_states[parent_frame],
+            )
+
+            returned_frames.append(outer_frame)
+
+        outer()
+
+        self.assertNotIn(
+            returned_frames[0],
+            self.dispatcher._frame_states,
+        )
+        self.assertIn(
+            sys._getframe(),
+            self.dispatcher._frame_states,
+        )
+
+    def test_stop_clears_active_ancestor_frame_state(self):
+        global MODULE_LEVEL_COUNTER
+        MODULE_LEVEL_COUNTER = {"value": 0}
+
+        def register_global():
+            self.dispatcher.register(
+                "MODULE_LEVEL_COUNTER",
+                frame=sys._getframe(),
+            )
+
+        register_global()
+
+        active_ancestor = sys._getframe()
+
+        self.assertIn(
+            active_ancestor,
+            self.dispatcher._frame_states,
+        )
+
+        self.dispatcher.stop()
+
+        self.assertNotIn(
+            active_ancestor,
+            self.dispatcher._frame_states,
+        )
+        self.assertEqual(
+            self.dispatcher._frame_states,
+            {},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- 하위 함수에서 변수를 등록한 경우 이미 실행 중인 상위 프레임의 변경이 기록되지 않던 문제를 해결했다.
- 등록 시점에 활성화된 부모 함수와 모듈 프레임까지 추적 범위를 확장하여 전역 변수의 변경 이력이 누락되지 않도록 개선했다.
- 조상 프레임 탐색이 `<module>` 프레임 경계를 넘어가지 않도록 하여, 같은 globals를 공유하는 무관한 실행 단위(중첩 `exec()`, 노트북 셀 러너 등)나 이 코드를 호출한 인터프리터/테스트 러너 프레임까지 추적 대상으로 잘못 판정되는 문제를 추가로 해결했다.

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] `register()` 호출 시 `frame.f_back`을 따라 활성 상위 프레임을 확인하고, 등록된 변수와 관련 있는 프레임에 tracing을 설정하도록 구현했다.
- [x] 기존 frame relevance 판정을 활용하여 같은 이름의 지역 변수가 전역 변수를 가리는 무관한 프레임은 추적 대상에서 제외했다.
- [x] 조상 프레임 탐색 중 `co_name == "<module>"`인 프레임에 도달하면 그 프레임까지만 처리하고 탐색을 멈추도록 하여, 실행 단위 경계를 넘어선 오추적을 방지했다.
- [x] 모듈 프레임과 부모 함수 프레임에서 발생하는 전역 변수 변경을 검증하는 회귀 테스트를 추가했다.
- [x] 프레임별 추적 상태가 서로 격리되며, 함수 반환과 `stop()` 호출 시 정상적으로 정리되는지 검증하는 테스트를 추가했다.
- [x] 중첩 `exec()`가 같은 globals dict를 공유하는 상황에서 조상 추적이 `<module>` 경계를 넘지 않는지 검증하는 테스트를 추가했다.
- [x] `docs/FrameAttachment.md`를 조상 프레임 추적 방식과 `<module>` 경계 정지 이유를 설명하도록 수정했다.

## Issue Link
<!-- Link any related issues below. e.g., Closes #12 -->
- Closes #39

## Screenshots / Videos (Optional)
<!-- Attach any visual evidence, mockups, or demos if there are UI/UX changes. -->
- UI/UX 변경 사항이 없어 첨부 자료는 없다.

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging logs (e.g., console.log, print) and comments.