### PR TITLE
CI: merge release/hotfix PRs directly with the App so ruleset bypass applies

### DIFF
--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -4,7 +4,10 @@ name: Finish Release / Hotfix
 # it" — then everything is unattended:
 #   1. tag vX.Y.Z at the release/hotfix tip
 #   2. open branch→master and branch→develop PRs (App token, so test.yml triggers)
-#   3. enable auto-merge on both (Ruleset A bypasses approval for the App)
+#   3. enable auto-merge on both as a FALLBACK (fires only if a human approves)
+# The real merge is done by merge-release.yml: the App merges directly once CI is
+# green, which is what actually bypasses require-approval — GitHub auto-merge does NOT
+# use the App's ruleset bypass, so on its own it would sit at REVIEW_REQUIRED forever.
 # The GitHub Release + branch deletion happen later in post-merge.yml, only after
 # BOTH PRs merge (§2 note: 2→3 is not a synchronous continuation).
 #
@@ -101,8 +104,9 @@ jobs:
               } else {
                 core.notice(`Reusing existing ${branch} → ${base} (#${pr.number}).`);
               }
-              // Enable auto-merge (Ruleset A bypasses approval for the App; Ruleset B
-              // still requires CI green before this merges).
+              // Enable auto-merge as a FALLBACK only (fires if a human approves).
+              // The primary merge path is merge-release.yml, where the App merges
+              // directly once CI is green — auto-merge does NOT use the App's bypass.
               await github.graphql(
                 `mutation($id: ID!) {
                    enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: MERGE }) {

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -1,0 +1,82 @@
+name: Merge Release / Hotfix
+
+# Closes the gap finalize.yml leaves open. finalize only ENABLES auto-merge on the
+# release/*→master and →develop PRs, but GitHub auto-merge does NOT use the App's
+# ruleset bypass — so with the "require-approval" ruleset active (1 approval +
+# require_last_push_approval) those PRs sit at REVIEW_REQUIRED forever.
+#
+# Bypass is a permission to MERGE despite a rule, not an automatic action: it only
+# takes effect when the bypass actor actually performs the merge. So here the App
+# merges the PRs DIRECTLY (pulls.merge) once CI is green. The App is a bypass actor on
+# require-approval, so the approval rule is bypassed. require-ci-* have no bypass but
+# are already satisfied — that is exactly what "Run Tests" success means — and
+# require-uptodate-develop is bypassed too. See GitFlowPipeline.md §2.
+#
+# Triggered by workflow_run (not pull_request) because at finalize time CI is still
+# pending; we can only merge once the checks report success. This file must live on
+# the default branch (master) for workflow_run to fire.
+on:
+  workflow_run:
+    workflows: ["Run Tests"]
+    types: [completed]
+
+# Both release PRs share the same head branch and their two Run Tests runs finish near
+# each other. Serialize per-branch and keep pulls.merge idempotent (405/409 tolerated)
+# so we never double-merge or fail on an already-merged PR.
+concurrency:
+  group: merge-release-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Merge release/hotfix PRs directly
+    runs-on: ubuntu-latest
+    # Only for a green Run Tests on a release/* or hotfix/* head.
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      (startsWith(github.event.workflow_run.head_branch, 'release/') ||
+       startsWith(github.event.workflow_run.head_branch, 'hotfix/'))
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Merge open release/hotfix PRs (App bypasses approval)
+        uses: actions/github-script@v7
+        with:
+          # App token so the merge actor IS the App — the ruleset bypass actor. A merge
+          # with GITHUB_TOKEN would not carry the bypass and would stay blocked.
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.payload.workflow_run.head_branch;
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', head: `${owner}:${branch}`, per_page: 100,
+            });
+            const targets = prs.filter(p => ['master', 'develop'].includes(p.base.ref));
+            if (targets.length === 0) {
+              core.notice(`No open ${branch} → master/develop PRs; nothing to merge.`);
+              return;
+            }
+
+            for (const pr of targets) {
+              try {
+                await github.rest.pulls.merge({
+                  owner, repo, pull_number: pr.number, merge_method: 'merge',
+                });
+                core.notice(`Merged #${pr.number} (${branch} → ${pr.base.ref}).`);
+              } catch (e) {
+                // 405: not mergeable yet (the OTHER PR's checks may still be pending) —
+                //      that PR's own Run Tests completion re-triggers this workflow.
+                // 409: base moved between list and merge — same re-trigger covers it.
+                if (e.status === 405 || e.status === 409) {
+                  core.warning(`#${pr.number} not mergeable yet (${e.status}); will retry on next run.`);
+                } else {
+                  throw e;
+                }
+              }
+            }


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of the overall changes in this PR. -->
- `finalize.yml`은 release/hotfix PR에 auto-merge만 걸어두는데, GitHub auto-merge는 App의 ruleset bypass를 쓰지 않아 `require-approval`(승인 1개 + last-push-approval)에 걸려 PR이 REVIEW_REQUIRED로 멈춘다.
- `Run Tests`가 green이면 App이 PR을 직접 머지(`pulls.merge`)하는 워크플로를 추가해, App이 bypass actor인 `require-approval`을 실제로 우회하도록 한다.

## Key Changes
<!-- List the core updates and code modifications made in this PR. -->
- [x] `merge-release.yml` 추가 — `Run Tests` success(`workflow_run`) 시 `release/*`·`hotfix/*` head의 `→master`/`→develop` PR을 App 토큰으로 직접 머지. 405/409는 다음 실행에서 재시도, concurrency로 중복 머지 방지.
- [x] `finalize.yml` 주석 정정 — auto-merge "으로 표기하고, 실제 머지 경로는`merge-release.yml`임을 명시.

---

## Checklist
- [x] My code follows the coding style and guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have verified and tested the changes successfully.
- [x] I have removed unnecessary debugging l) and comments.